### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install sox (oracle for parity tests)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends sox
+
+      - name: Check gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -race ./...


### PR DESCRIPTION
## Summary

Adds a CI workflow that gates pushes to main and pull requests:

- gofmt check (fails listing unformatted files)
- go vet ./...
- go build ./...
- go test -race ./...

The workflow installs sox from apt (14.4.2 on ubuntu-latest), so the oracle and parity tests in the sox package run against the real binary instead of skipping. Actions are pinned to commit SHAs (actions/checkout v6.0.3, actions/setup-go v6.4.0), permissions are restricted to contents: read, and superseded PR runs are cancelled via a concurrency group.

## Test Plan

- [x] All workflow steps pass locally (gofmt clean, vet clean, build clean, go test -race ok)
- [x] actionlint reports no issues
- [ ] CI run on this PR goes green, including the sox parity tests