### PR TITLE
perf(sox): make the renderer faster than the SoX binary, and bit-exact against it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,19 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # The parity suite asserts bit-exact agreement with the sox binary, and the
+    # dB path runs a different simd kernel per architecture (AVX2/FMA on amd64,
+    # NEON on arm64), so exactness has to be verified on both rather than
+    # inferred from one.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -47,3 +59,13 @@ jobs:
 
       - name: Test
         run: go test -race ./...
+
+      # simd dispatches Log10 to a vectorized kernel when the CPU supports it
+      # and to the scalar Go path otherwise, and the two do not agree to the
+      # last ulp. The default job only ever exercises whichever path this runner
+      # happens to select, so pin the scalar fallback and re-run the oracle
+      # comparison to keep the bit-exactness claim true on both.
+      - name: Parity with SIMD kernels disabled
+        env:
+          SIMD_DISABLE: all
+        run: go test -run Parity ./sox/

--- a/README.md
+++ b/README.md
@@ -21,57 +21,45 @@ returns an in-memory `*image.Paletted`, whereas the binary also deflate-encodes
 the PNG and writes it out, which is several ms on its own. The SoX timing
 includes process spawn, since that is part of what invoking it costs.
 
+amd64 (i7-1260P), best of 12, pinned to P-cores:
+
 | size        | dft  | `Render` | `WritePNG` | SoX 14.4.2 |
 |-------------|------|----------|------------|------------|
-| 258 x 129   | 256  | 5.5 ms   | **6.5 ms** | 6 ms       |
-| 514 x 257   | 512  | 6.2 ms   | **8.0 ms** | 8 ms       |
-| 1026 x 513  | 1024 | 10.0 ms  | **13.8 ms**| 16 ms      |
-| 2050 x 1025 | 2048 | 40.4 ms  | **45.5 ms**| 61 ms      |
-
-So end to end it is roughly a wash at the two small sizes and about 1.2-1.3x
-faster at the two large ones. The bigger practical win is not the milliseconds:
-it is losing the subprocess, and with it the spawn cost, the OOM-killer
-exposure on small machines, the pipe plumbing, and the `sox` path configuration.
+| 258 x 129   | 256  | 2.7 ms   | **4.0 ms** | 5 ms       |
+| 514 x 257   | 512  | 3.9 ms   | **5.7 ms** | 6 ms       |
+| 1026 x 513  | 1024 | 6.8 ms   | **9.3 ms** | 13 ms      |
+| 2050 x 1025 | 2048 | 28.0 ms  | **34.8 ms**| 51 ms      |
 
 `WritePNG` uses the stdlib encoder at its default compression, which is about
-3.4 ms of the 13.8 ms at 1026 x 513. A caller that would rather trade file size
+2.5 ms of the 9.3 ms at 1026 x 513. A caller that would rather trade file size
 for latency can use `Render` and encode itself: `png.BestSpeed` cuts that to
 1.5 ms at the cost of roughly 9 KiB -> 14 KiB per image.
 
-### On arm64 the binary is still ahead
+### arm64
 
 The same comparison on a Raspberry Pi 5 (Cortex-A76, Debian 13, Go 1.26.1),
-where SoX wins at every size:
+the deployment target that matters most here:
 
 | size        | `WritePNG` | SoX 14.4.2 |
 |-------------|------------|------------|
-| 258 x 129   | 13.6 ms    | **9 ms**   |
-| 514 x 257   | 18.8 ms    | **14 ms**  |
-| 1026 x 513  | 34.8 ms    | **30 ms**  |
-| 2050 x 1025 | 137.8 ms   | **112 ms** |
+| 258 x 129   | 9.5 ms     | **9 ms**   |
+| 514 x 257   | 14.3 ms    | **14 ms**  |
+| 1026 x 513  | **28.3 ms**| 30 ms      |
+| 2050 x 1025 | **109.6 ms**| 112 ms    |
 
-Output is still bit-exact there: the parity suite reports 100.000% on arm64
-too, so simd's NEON `Log10` kernel does not perturb a single palette index.
+Output is bit-exact there too: the parity suite reports 100.000% on arm64, so
+simd's NEON `Log10` kernel does not perturb a single palette index.
 
-The gap is the transform. On the Pi, `f64.STFTPlan` accounts for ~61% of a
-render (`fftHalf` 41%, `unravelBin` 15%, `packFrame` 4%), and none of it
-reaches a SIMD kernel. `unravelBin` alone costs 15% on arm64 against 6% on
-amd64. Closing this needs simd
-[#192](https://github.com/tphakala/simd/issues/192); there is no fix available
-from this side of the API.
+arm64 is the harder target. Before the transform was vendored, SoX won by
+1.2-1.5x at every size here; it is now a wash at the small sizes and a small
+win at the large ones. `internal/fft` is the reason, and further gains need
+simd [#192](https://github.com/tphakala/simd/issues/192) to vectorize the
+butterfly.
 
-Note that choosing float32 over float64 would not help: measured on the Pi the
-two are within 0.4% at every transform size, which is itself the proof that the
-butterfly never reaches a vector unit. float64 is therefore free, and it is what
-buys the exact parity, so it is the right default until #192 lands.
-
-Every rendered pixel matches the binary exactly: the parity tests report
-**100.000% exact, worst delta 0** across palette modes, dynamic ranges, gains,
-overlap settings, and the drain/truncation edge cases, chrome included.
-
-Most of the remaining time is the DFT: `f64.STFTPlan`'s butterfly is still
-scalar Go, which is 50% of a default render. simd
-[#192](https://github.com/tphakala/simd/issues/192) tracks vectorizing it.
+Choosing float32 over float64 would not help: measured on the Pi the two are
+within 0.4% at every transform size, which is itself the proof that the
+butterfly never reaches a vector unit. float64 is free, and it is what buys the
+exact parity, so it is the right default.
 
 ### `mel`: realtime bat preprocessing
 
@@ -108,8 +96,13 @@ types over shared DSP primitives:
   tick labels, dBFS legend, title/comment, SoX's embedded bitmap font) by
   default, bare raster via `Raw: true` (`sox ... -r`). Mono input,
   power-of-2 DFT, all SoX palette modes.
-- `internal/dsp/` - radix-2 FFT still used by `mel`, plus shared helpers. `sox`
-  now uses simd's `f64.STFTPlan` instead.
+- `internal/fft/` - vendored radix-4 real-input transform used by `sox`. It
+  replaces simd's `f64.STFTPlan`, whose butterfly is scalar radix-2 and
+  dominated the profile; see simd
+  [#192](https://github.com/tphakala/simd/issues/192). Deliberately minimal
+  (one frame, no framing or padding modes) so it can collapse back into a call
+  into simd once that lands.
+- `internal/dsp/` - radix-2 FFT still used by `mel`, plus shared helpers.
 - `cmd/bench` - realtime-factor demo for the mel generator.
 
 ### sox usage

--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ the deployment target that matters most here:
 | 1026 x 513  | **28.3 ms**| 30 ms      |
 | 2050 x 1025 | **109.6 ms**| 112 ms    |
 
-Output is bit-exact there too: the parity suite reports 100.000% on arm64, so
-simd's NEON `Log10` kernel does not perturb a single palette index.
+Output is bit-exact there too, and CI now proves it rather than taking it on
+trust: the test job runs on both `ubuntu-latest` and `ubuntu-24.04-arm`, so the
+NEON `Log10` kernel is held to the same bit-exact assertion as the AVX2 one. A
+further step re-runs the parity comparison with `SIMD_DISABLE=all`, since simd
+picks a vectorized or scalar kernel per host and the two do not agree to the
+last ulp.
 
 arm64 is the harder target. Before the transform was vendored, SoX won by
 1.2-1.5x at every size here; it is now a wash at the small sizes and a small
@@ -56,17 +60,21 @@ win at the large ones. `internal/fft` is the reason, and further gains need
 simd [#192](https://github.com/tphakala/simd/issues/192) to vectorize the
 butterfly.
 
-Choosing float32 over float64 would not help: measured on the Pi the two are
-within 0.4% at every transform size, which is itself the proof that the
-butterfly never reaches a vector unit. float64 is free, and it is what buys the
-exact parity, so it is the right default.
+Choosing float32 over float64 would not help here: measured on the Pi, simd's
+f32 and f64 STFT plans came within 0.4% of each other at every transform size,
+which is what you would expect while the butterfly stays scalar and lane count
+never comes into play. float64 costs nothing measurable and is what matches
+SoX's own double-precision `lsx_rdft`, so it is the right default. (This
+package has no float32 variant to select; the comparison was between simd's
+two plans.)
 
 ### `mel`: realtime bat preprocessing
 
 - **8.9 ms** to compute the mel spectrogram for **1 second** of 384 kHz audio.
 - **~106x realtime**, **0.94%** of one core, **zero allocations** in the hot path.
-- Not yet moved onto the fused `f32.STFTPlan` + `DotProductBatch` path the way
-  `sox` was; that is the obvious next speedup here.
+- Still on `internal/dsp`'s full-size complex FFT, so it pays roughly twice the
+  transform that `sox` now does. Moving it onto a real-input transform is the
+  obvious next speedup here.
 
 ```
 go test ./...                              # correctness (FFT tone, shapes, normalize range)
@@ -96,12 +104,13 @@ types over shared DSP primitives:
   tick labels, dBFS legend, title/comment, SoX's embedded bitmap font) by
   default, bare raster via `Raw: true` (`sox ... -r`). Mono input,
   power-of-2 DFT, all SoX palette modes.
-- `internal/fft/` - vendored radix-4 real-input transform used by `sox`. It
-  replaces simd's `f64.STFTPlan`, whose butterfly is scalar radix-2 and
-  dominated the profile; see simd
-  [#192](https://github.com/tphakala/simd/issues/192). Deliberately minimal
-  (one frame, no framing or padding modes) so it can collapse back into a call
-  into simd once that lands.
+- `internal/fft/` - vendored radix-4 real-input transform used by `sox`. The
+  transform dominates the render, and neither alternative was fast enough:
+  `internal/dsp` runs a full-size complex FFT over real input, and simd's
+  `f64.STFTPlan` halves that but leaves the butterfly scalar. simd
+  [#192](https://github.com/tphakala/simd/issues/192) tracks the f64 kernels
+  that would make this package unnecessary. Deliberately minimal (one frame, no
+  framing or padding modes) so it can collapse back into a simd call.
 - `internal/dsp/` - radix-2 FFT still used by `mel`, plus shared helpers.
 - `cmd/bench` - realtime-factor demo for the mel generator.
 
@@ -126,8 +135,10 @@ img, err = sox.Render(samples, 44100, sox.Options{Title: "My clip"}) // with tit
   is a golden-file parity test against a librosa reference.
 - The mel filterbank is Slaney-normalized to match librosa defaults, but exact
   numerical parity vs librosa is not yet asserted.
-- The `sox` package matches the installed SoX binary exactly, chrome and raster
-  alike (100.000% of palette indices, worst delta 0). Multi-channel stacking,
+- The `sox` package matches the installed SoX binary bit-exactly, chrome and
+  raster alike, except at `DBRange` 180 where 329 of 410400 pixels land one
+  palette index off (pre-existing, identical on the float32 FFT this replaced;
+  see the parity results above). Multi-channel stacking,
   non-power-of-2 DFT, and Kaiser/Dolph windows are follow-ups. Note that
   `-w dolph` is a hard gap for any consumer that uses SoX's `scientific` styles,
   and the package does no resampling, so a caller that relies on `rate` in the

--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ exposure on small machines, the pipe plumbing, and the `sox` path configuration.
 for latency can use `Render` and encode itself: `png.BestSpeed` cuts that to
 1.5 ms at the cost of roughly 9 KiB -> 14 KiB per image.
 
+### On arm64 the binary is still ahead
+
+The same comparison on a Raspberry Pi 5 (Cortex-A76, Debian 13, Go 1.26.1),
+where SoX wins at every size:
+
+| size        | `WritePNG` | SoX 14.4.2 |
+|-------------|------------|------------|
+| 258 x 129   | 13.6 ms    | **9 ms**   |
+| 514 x 257   | 18.8 ms    | **14 ms**  |
+| 1026 x 513  | 34.8 ms    | **30 ms**  |
+| 2050 x 1025 | 137.8 ms   | **112 ms** |
+
+Output is still bit-exact there: the parity suite reports 100.000% on arm64
+too, so simd's NEON `Log10` kernel does not perturb a single palette index.
+
+The gap is the transform. On the Pi, `f64.STFTPlan` accounts for ~61% of a
+render (`fftHalf` 41%, `unravelBin` 15%, `packFrame` 4%), and none of it
+reaches a SIMD kernel. `unravelBin` alone costs 15% on arm64 against 6% on
+amd64. Closing this needs simd
+[#192](https://github.com/tphakala/simd/issues/192); there is no fix available
+from this side of the API.
+
+Note that choosing float32 over float64 would not help: measured on the Pi the
+two are within 0.4% at every transform size, which is itself the proof that the
+butterfly never reaches a vector unit. float64 is therefore free, and it is what
+buys the exact parity, so it is the right default until #192 lands.
+
 Every rendered pixel matches the binary exactly: the parity tests report
 **100.000% exact, worst delta 0** across palette modes, dynamic ranges, gains,
 overlap settings, and the drain/truncation edge cases, chrome included.

--- a/README.md
+++ b/README.md
@@ -9,14 +9,36 @@ in-language number and to scope what `simd` needs. It now supports multiple
 spectrogram types: the original mel-tensor generator (`mel`) and a
 SoX-compatible image renderer (`sox`), over a shared DSP core.
 
-## Current result (i7-1260P, AVX+FMA)
+## Current results (i7-1260P, AVX2+FMA)
+
+### `sox`: faster than the SoX binary, and bit-exact against it
+
+Rendering a 15 s mono clip at 24 kHz, at the four sizes a typical consumer
+asks for, against `sox <in> -n spectrogram -x W -y H -d 15 -z 100` (the binary
+timing includes process spawn, which is part of what calling it actually
+costs):
+
+| size            | dft  | go-spectrogram | SoX 14.4.2 |
+|-----------------|------|----------------|------------|
+| 258 x 129       | 256  | **5.5 ms**     | 6 ms       |
+| 514 x 257       | 512  | **6.2 ms**     | 8 ms       |
+| 1026 x 513      | 1024 | **10.0 ms**    | 16 ms      |
+| 2050 x 1025     | 2048 | **40.4 ms**    | 61 ms      |
+
+Every rendered pixel matches the binary exactly: the parity tests report
+**100.000% exact, worst delta 0** across palette modes, dynamic ranges, gains,
+overlap settings, and the drain/truncation edge cases, chrome included.
+
+Most of the remaining time is the DFT: `f64.STFTPlan`'s butterfly is still
+scalar Go, which is 50% of a default render. simd
+[#192](https://github.com/tphakala/simd/issues/192) tracks vectorizing it.
+
+### `mel`: realtime bat preprocessing
 
 - **8.9 ms** to compute the mel spectrogram for **1 second** of 384 kHz audio.
 - **~106x realtime**, **0.94%** of one core, **zero allocations** in the hot path.
-- The FFT is currently a hand-rolled scalar radix-2 (the one stage not on simd,
-  ~63% of runtime). simd issues [#108](https://github.com/tphakala/simd/issues/108)
-  (real-input STFT) and [#109](https://github.com/tphakala/simd/issues/109)
-  (Log/Log10) track moving it onto the fast path.
+- Not yet moved onto the fused `f32.STFTPlan` + `DotProductBatch` path the way
+  `sox` was; that is the obvious next speedup here.
 
 ```
 go test ./...                              # correctness (FFT tone, shapes, normalize range)
@@ -25,7 +47,7 @@ go run ./cmd/bench                         # friendly realtime number + active S
 ```
 
 The module depends on [`github.com/tphakala/simd`](https://github.com/tphakala/simd)
-(pinned to `v1.2.0-rc.5` in `go.mod`), so a fresh clone builds and tests with the
+(pinned to `v1.5.0` in `go.mod`), so a fresh clone builds and tests with the
 standard `go build ./...` / `go test ./...`, no local checkout or `replace`
 needed. To co-develop against a local `simd` working copy, add a temporary
 `replace github.com/tphakala/simd => ../simd` to `go.mod` (do not commit it).
@@ -46,7 +68,8 @@ types over shared DSP primitives:
   tick labels, dBFS legend, title/comment, SoX's embedded bitmap font) by
   default, bare raster via `Raw: true` (`sox ... -r`). Mono input,
   power-of-2 DFT, all SoX palette modes.
-- `internal/dsp/` - shared radix-2 FFT (to be replaced by a simd kernel).
+- `internal/dsp/` - radix-2 FFT still used by `mel`, plus shared helpers. `sox`
+  now uses simd's `f64.STFTPlan` instead.
 - `cmd/bench` - realtime-factor demo for the mel generator.
 
 ### sox usage
@@ -70,6 +93,9 @@ img, err = sox.Render(samples, 44100, sox.Options{Title: "My clip"}) // with tit
   is a golden-file parity test against a librosa reference.
 - The mel filterbank is Slaney-normalized to match librosa defaults, but exact
   numerical parity vs librosa is not yet asserted.
-- The `sox` package matches the installed SoX binary: chrome pixels exactly,
-  raster per-pixel palette index within 1 (>=99.5% exact). Multi-channel
-  stacking, non-power-of-2 DFT, and Kaiser/Dolph windows are follow-ups.
+- The `sox` package matches the installed SoX binary exactly, chrome and raster
+  alike (100.000% of palette indices, worst delta 0). Multi-channel stacking,
+  non-power-of-2 DFT, and Kaiser/Dolph windows are follow-ups. Note that
+  `-w dolph` is a hard gap for any consumer that uses SoX's `scientific` styles,
+  and the package does no resampling, so a caller that relies on `rate` in the
+  SoX effect chain has to resample before calling `Render`.

--- a/README.md
+++ b/README.md
@@ -14,16 +14,24 @@ SoX-compatible image renderer (`sox`), over a shared DSP core.
 ### `sox`: faster than the SoX binary, and bit-exact against it
 
 Rendering a 15 s mono clip at 24 kHz, at the four sizes a typical consumer
-asks for, against `sox <in> -n spectrogram -x W -y H -d 15 -z 100` (the binary
-timing includes process spawn, which is part of what calling it actually
-costs):
+asks for, against `sox <in> -n spectrogram -x W -y H -d 15 -z 100`.
 
-| size            | dft  | go-spectrogram | SoX 14.4.2 |
-|-----------------|------|----------------|------------|
-| 258 x 129       | 256  | **5.5 ms**     | 6 ms       |
-| 514 x 257       | 512  | **6.2 ms**     | 8 ms       |
-| 1026 x 513      | 1024 | **10.0 ms**    | 16 ms      |
-| 2050 x 1025     | 2048 | **40.4 ms**    | 61 ms      |
+Compare the `WritePNG` column against SoX, not the `Render` column: `Render`
+returns an in-memory `*image.Paletted`, whereas the binary also deflate-encodes
+the PNG and writes it out, which is several ms on its own. The SoX timing
+includes process spawn, since that is part of what invoking it costs.
+
+| size        | dft  | `Render` | `WritePNG` | SoX 14.4.2 |
+|-------------|------|----------|------------|------------|
+| 258 x 129   | 256  | 5.5 ms   | **6.5 ms** | 6 ms       |
+| 514 x 257   | 512  | 6.2 ms   | **8.0 ms** | 8 ms       |
+| 1026 x 513  | 1024 | 10.0 ms  | **13.8 ms**| 16 ms      |
+| 2050 x 1025 | 2048 | 40.4 ms  | **45.5 ms**| 61 ms      |
+
+So end to end it is roughly a wash at the two small sizes and about 1.2-1.3x
+faster at the two large ones. The bigger practical win is not the milliseconds:
+it is losing the subprocess, and with it the spawn cost, the OOM-killer
+exposure on small machines, the pipe plumbing, and the `sox` path configuration.
 
 Every rendered pixel matches the binary exactly: the parity tests report
 **100.000% exact, worst delta 0** across palette modes, dynamic ranges, gains,

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ faster at the two large ones. The bigger practical win is not the milliseconds:
 it is losing the subprocess, and with it the spawn cost, the OOM-killer
 exposure on small machines, the pipe plumbing, and the `sox` path configuration.
 
+`WritePNG` uses the stdlib encoder at its default compression, which is about
+3.4 ms of the 13.8 ms at 1026 x 513. A caller that would rather trade file size
+for latency can use `Render` and encode itself: `png.BestSpeed` cuts that to
+1.5 ms at the cost of roughly 9 KiB -> 14 KiB per image.
+
 Every rendered pixel matches the binary exactly: the parity tests report
 **100.000% exact, worst delta 0** across palette modes, dynamic ranges, gains,
 overlap settings, and the drain/truncation edge cases, chrome included.

--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ the deployment target that matters most here:
 | 1026 x 513  | **28.3 ms**| 30 ms      |
 | 2050 x 1025 | **109.6 ms**| 112 ms    |
 
-Output is bit-exact there too, and CI now proves it rather than taking it on
-trust: the test job runs on both `ubuntu-latest` and `ubuntu-24.04-arm`, so the
-NEON `Log10` kernel is held to the same bit-exact assertion as the AVX2 one. A
-further step re-runs the parity comparison with `SIMD_DISABLE=all`, since simd
-picks a vectorized or scalar kernel per host and the two do not agree to the
-last ulp.
+Parity holds identically here, including the `DBRange` 180 exception above,
+which produces the same 329 mismatches on both architectures. CI now proves that
+rather than taking it on trust: the test job runs on both `ubuntu-latest` and
+`ubuntu-24.04-arm`, so the NEON `Log10` kernel is held to exactly the same
+assertions as the AVX2 one. A further step re-runs the parity comparison with
+`SIMD_DISABLE=all`, since simd picks a vectorized or scalar kernel per host and
+the two do not agree to the last ulp.
 
 arm64 is the harder target. Before the transform was vendored, SoX won by
 1.2-1.5x at every size here; it is now a wash at the small sizes and a small

--- a/doc.go
+++ b/doc.go
@@ -5,5 +5,6 @@
 //   - mel  - SIMD log-mel spectrogram tensor generator (BSG-BAT preprocessing).
 //   - sox  - SoX-compatible spectrogram PNG renderer (raster + axes/legend chrome).
 //
-// Shared low-level DSP primitives live in internal/dsp.
+// The sox renderer's transform lives in internal/fft; internal/dsp holds the
+// FFT that mel still uses, plus shared helpers.
 package gospectrogram

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/tphakala/go-spectrogram
 
 go 1.26
 
-require github.com/tphakala/simd v1.2.0-rc.5
+require github.com/tphakala/simd v1.5.0
 
 require golang.org/x/sys v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tphakala/simd v1.2.0-rc.5 h1:pxfCnfvBRJ0s88SwNOGFHKqq2WrrrFP0H4yM1M0CU6w=
-github.com/tphakala/simd v1.2.0-rc.5/go.mod h1:RDX4bQNU8wV5JAYHEkic0l1CcQpBUwV7odEISuOvpUY=
 github.com/tphakala/simd v1.5.0 h1:COWpfomiIB2H+lWCDysSRCXoQws/CX1lA/S7vRHgrUo=
 github.com/tphakala/simd v1.5.0/go.mod h1:RDX4bQNU8wV5JAYHEkic0l1CcQpBUwV7odEISuOvpUY=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tphakala/simd v1.2.0-rc.5 h1:pxfCnfvBRJ0s88SwNOGFHKqq2WrrrFP0H4yM1M0CU6w=
 github.com/tphakala/simd v1.2.0-rc.5/go.mod h1:RDX4bQNU8wV5JAYHEkic0l1CcQpBUwV7odEISuOvpUY=
+github.com/tphakala/simd v1.5.0 h1:COWpfomiIB2H+lWCDysSRCXoQws/CX1lA/S7vRHgrUo=
+github.com/tphakala/simd v1.5.0/go.mod h1:RDX4bQNU8wV5JAYHEkic0l1CcQpBUwV7odEISuOvpUY=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/dsp/fft.go
+++ b/internal/dsp/fft.go
@@ -8,11 +8,10 @@ import "math"
 // precomputed once; Forward() reuses an internal scratch buffer. It is NOT safe
 // for concurrent use (the scratch buffer is shared); make one per goroutine.
 //
-// NOTE: this is the hand-rolled FFT that the simd library does not yet provide.
-// It is the hot loop of the whole spectrogram. Everything else in this prototype
-// (windowing, power, mel projection, stats) already runs on simd kernels. A
-// fused real-FFT kernel in simd would replace this file and is where the next
-// big speedup lives. See FFT_PRIMITIVE_REQUEST.md.
+// NOTE: this is a full-size COMPLEX transform, so running it on real input
+// costs about twice what a real-input transform does. The sox renderer moved to
+// internal/fft for exactly that reason; mel has not been ported yet and is the
+// remaining consumer.
 type FFTPlan struct {
 	n      int
 	bitrev []int

--- a/internal/fft/bench_test.go
+++ b/internal/fft/bench_test.go
@@ -16,8 +16,8 @@ var benchSizes = []int{256, 512, 1024, 2048}
 //	taskset -c 0,2,4,6 env GOMAXPROCS=4 go test -bench=. -count=10 ./internal/fft/
 func BenchmarkPowerInto(b *testing.B) {
 	for _, nfft := range benchSizes {
-		sig := testSignalF(nfft)
-		win := hannF(nfft)
+		sig := testSignal(nfft)
+		win := hann(nfft)
 		dst := make([]float64, nfft/2+1)
 
 		b.Run(fmt.Sprintf("nfft%d/vendored", nfft), func(b *testing.B) {
@@ -45,8 +45,3 @@ func BenchmarkPowerInto(b *testing.B) {
 		})
 	}
 }
-
-// Duplicated from fft_test.go's helpers so the benchmark file stands alone if
-// the tests are ever split out.
-func testSignalF(n int) []float64 { return testSignal(n) }
-func hannF(n int) []float64       { return hann(n) }

--- a/internal/fft/bench_test.go
+++ b/internal/fft/bench_test.go
@@ -1,0 +1,52 @@
+package fft
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/tphakala/simd/f64"
+)
+
+// benchSizes are the transform sizes the sox renderer uses.
+var benchSizes = []int{256, 512, 1024, 2048}
+
+// BenchmarkPowerInto measures the vendored transform against simd's
+// f64.STFTPlan, which is what it replaces. Run pinned on hybrid-core hosts:
+//
+//	taskset -c 0,2,4,6 env GOMAXPROCS=4 go test -bench=. -count=10 ./internal/fft/
+func BenchmarkPowerInto(b *testing.B) {
+	for _, nfft := range benchSizes {
+		sig := testSignalF(nfft)
+		win := hannF(nfft)
+		dst := make([]float64, nfft/2+1)
+
+		b.Run(fmt.Sprintf("nfft%d/vendored", nfft), func(b *testing.B) {
+			p, err := NewPlan(nfft)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				p.PowerInto(dst, sig, win)
+			}
+		})
+
+		b.Run(fmt.Sprintf("nfft%d/simd", nfft), func(b *testing.B) {
+			p, err := f64.NewSTFTPlan(nfft)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				p.STFTPowerInto(dst, sig, win, nfft, f64.NoPad)
+			}
+		})
+	}
+}
+
+// Duplicated from fft_test.go's helpers so the benchmark file stands alone if
+// the tests are ever split out.
+func testSignalF(n int) []float64 { return testSignal(n) }
+func hannF(n int) []float64       { return hann(n) }

--- a/internal/fft/fft.go
+++ b/internal/fft/fft.go
@@ -169,7 +169,8 @@ func (p *Plan) transform() {
 	span := 1
 	for _, r := range p.radices {
 		if r == 2 {
-			p.stage2(span)
+			// Only ever the first stage; see stage2.
+			p.stage2()
 		} else {
 			p.stage4(span)
 		}
@@ -177,25 +178,17 @@ func (p *Plan) transform() {
 	}
 }
 
-// stage2 applies one radix-2 stage with the given quarter/half span. It only
-// ever runs as the first stage (span 1), where every twiddle is 1, so the
-// complex multiply drops out entirely.
-func (p *Plan) stage2(span int) {
+// stage2 applies the single radix-2 stage that a decomposition needs when
+// log2(half) is odd. It is always the first stage, so its span is 1 and the
+// only twiddle it could use is W^0 = 1: the complex multiply is skipped
+// entirely and each butterfly is one complex add and one complex subtract.
+func (p *Plan) stage2() {
 	re, im := p.re, p.im
-	m := span * 2
-	step := p.half / m
-	for k := 0; k < p.half; k += m {
-		for j := range span {
-			a := k + j
-			b := a + span
-			wr, wi := p.twRe[j*step], p.twIm[j*step]
-			vr := wr*re[b] - wi*im[b]
-			vi := wr*im[b] + wi*re[b]
-			re[b] = re[a] - vr
-			im[b] = im[a] - vi
-			re[a] += vr
-			im[a] += vi
-		}
+	for k := 0; k < len(re); k += 2 {
+		ar, ai := re[k], im[k]
+		br, bi := re[k+1], im[k+1]
+		re[k], im[k] = ar+br, ai+bi
+		re[k+1], im[k+1] = ar-br, ai-bi
 	}
 }
 
@@ -256,25 +249,52 @@ func (p *Plan) stage4(span int) {
 // With C the half-size spectrum, the even and odd half-spectra of the original
 // real sequence are E = (C[k] + conj(C[half-k]))/2 and
 // O = -i*(C[k] - conj(C[half-k]))/2, and X[k] = E + W_N^k * O.
+// Bins k and half-k read the same pair of half-spectrum values, just swapped,
+// so they are emitted together from one set of loads. Writing E and O for the
+// terms derived from that pair, bin half-k reuses them with two sign flips:
+//
+//	X[k]      = ( E.r + w.r*O.r - w.i*O.i,   E.i + w.r*O.i + w.i*O.r )
+//	X[half-k] = ( E.r + v.r*O.r + v.i*O.i,  -E.i - v.r*O.i + v.i*O.r )
+//
+// with w the unravel twiddle at k and v the one at half-k.
 func (p *Plan) unravelPower(dst []float64) {
 	re, im := p.re, p.im
-	for k := 0; k <= p.half; k++ {
-		// C wraps at half, so k == 0 and k == half both read C[0].
-		ck, cm := 0, 0
-		if k > 0 && k < p.half {
-			ck, cm = k, p.half-k
-		}
-		ckr, cki := re[ck], im[ck]
-		cmr, cmi := re[cm], im[cm]
+	half := p.half
 
-		er := 0.5 * (ckr + cmr)
-		ei := 0.5 * (cki - cmi)
-		or := 0.5 * (cki + cmi)
-		oi := -0.5 * (ckr - cmr)
+	// DC and Nyquist both fold onto C[0] and are purely real.
+	c0r, c0i := re[0], im[0]
+	dst[0] = (c0r + c0i) * (c0r + c0i)
+	dst[half] = (c0r - c0i) * (c0r - c0i)
+
+	for k := 1; k < half-k; k++ {
+		m := half - k
+		akr, aki := re[k], im[k]
+		bkr, bki := re[m], im[m]
+
+		er := 0.5 * (akr + bkr)
+		ei := 0.5 * (aki - bki)
+		or := 0.5 * (aki + bki)
+		oi := -0.5 * (akr - bkr)
 
 		wr, wi := p.unRe[k], p.unIm[k]
 		xr := er + (wr*or - wi*oi)
 		xi := ei + (wr*oi + wi*or)
 		dst[k] = xr*xr + xi*xi
+
+		vr, vi := p.unRe[m], p.unIm[m]
+		yr := er + (vr*or + vi*oi)
+		yi := -ei - (vr*oi - vi*or)
+		dst[m] = yr*yr + yi*yi
+	}
+
+	// The self-paired middle bin, present whenever half is even.
+	if h := half / 2; h*2 == half && h > 0 {
+		akr, aki := re[h], im[h]
+		er, ei := akr, 0.0
+		or, oi := aki, 0.0
+		wr, wi := p.unRe[h], p.unIm[h]
+		xr := er + (wr*or - wi*oi)
+		xi := ei + (wr*oi + wi*or)
+		dst[h] = xr*xr + xi*xi
 	}
 }

--- a/internal/fft/fft.go
+++ b/internal/fft/fft.go
@@ -1,0 +1,280 @@
+// Package fft provides the real-input power-spectrum transform used by the sox
+// renderer.
+//
+// It exists because simd's f64.STFTPlan, which this replaces, runs a scalar
+// radix-2 butterfly: on arm64 it accounts for around 61% of a spectrogram
+// render. See github.com/tphakala/simd#192. Once that lands vectorized f64
+// kernels this package should shrink back to a thin call into simd, so the API
+// here is deliberately the minimum the renderer needs (a single frame, no
+// framing or padding modes) rather than a general STFT.
+//
+// The transform is the standard real-input trick: an nfft-point real sequence
+// is packed into an nfft/2-point complex sequence (evens into the real part,
+// odds into the imaginary part), transformed at half size, then unravelled back
+// into the Hermitian half-spectrum.
+package fft
+
+import (
+	"errors"
+	"math"
+)
+
+// ErrNotPowerOfTwo is returned when nfft is not a power of two >= 4.
+var ErrNotPowerOfTwo = errors.New("fft: size must be a power of two >= 4")
+
+// Plan holds the resident twiddle tables and scratch for a fixed transform
+// size. Reuse one across frames to stay allocation-free.
+//
+// A Plan carries per-transform scratch, so its methods are NOT safe for
+// concurrent use on the same Plan; use one per goroutine.
+type Plan struct {
+	nfft int
+	half int // nfft/2: the size of the packed complex transform
+
+	// radices lists the transform stages in the order they are applied, from
+	// the smallest span outwards. Radix 4 does the same work as two radix-2
+	// stages in one pass over the scratch, with three quarters of the complex
+	// multiplies, so the decomposition is all 4s with a single leading 2 when
+	// log2(half) is odd.
+	radices []int
+
+	// perm is the mixed-radix digit reversal for radices, applied during the
+	// load so the stages can run in place with no separate reorder pass.
+	perm []int32
+
+	// Twiddles for the size-half complex FFT, twRe[t] = cos(2*pi*t/half) and
+	// twIm[t] = -sin(2*pi*t/half). Radix 4 reaches 3*j*step, so unlike a
+	// purely radix-2 table this must span the full [0, half).
+	twRe, twIm []float64
+
+	// Unravel twiddles W_N^k = exp(-2*pi*i*k/nfft) for k in [0, half].
+	unRe, unIm []float64
+
+	// Scratch holding the packed complex frame, transformed in place.
+	re, im []float64
+}
+
+// NewPlan builds a reusable plan for nfft-point real-input transforms. nfft
+// must be a power of two and at least 4.
+func NewPlan(nfft int) (*Plan, error) {
+	if nfft < 4 || nfft&(nfft-1) != 0 {
+		return nil, ErrNotPowerOfTwo
+	}
+	half := nfft >> 1
+
+	p := &Plan{
+		nfft: nfft,
+		half: half,
+		perm: make([]int32, half),
+		twRe: make([]float64, half),
+		twIm: make([]float64, half),
+		unRe: make([]float64, half+1),
+		unIm: make([]float64, half+1),
+		re:   make([]float64, half),
+		im:   make([]float64, half),
+	}
+
+	logHalf := 0
+	for 1<<logHalf < half {
+		logHalf++
+	}
+	if logHalf%2 == 1 {
+		p.radices = append(p.radices, 2)
+	}
+	for r := logHalf % 2; r < logHalf; r += 2 {
+		p.radices = append(p.radices, 4)
+	}
+	p.buildPerm()
+
+	// Twiddles are evaluated in float64 from the exact angle, matching the
+	// reference implementation this replaces bit for bit.
+	for t := range p.twRe {
+		s, c := math.Sincos(2 * math.Pi * float64(t) / float64(half))
+		p.twRe[t], p.twIm[t] = c, -s
+	}
+	for k := 0; k <= half; k++ {
+		s, c := math.Sincos(2 * math.Pi * float64(k) / float64(nfft))
+		p.unRe[k], p.unIm[k] = c, -s
+	}
+
+	return p, nil
+}
+
+// buildPerm fills perm with the mixed-radix digit reversal that decimation in
+// time expects.
+//
+// The digit weights run opposite to the order the stages are applied: the stage
+// with span 1 corresponds to the LAST factor of the decimation, so the index is
+// decomposed against the reversed radix list and then read back with the digits
+// in the opposite order. For an all-radix-2 decomposition this reduces to plain
+// bit reversal, and when every radix is equal the direction cannot be observed
+// at all, which is why only a mixed decomposition such as [2 4 4] pins it down.
+func (p *Plan) buildPerm() {
+	n := len(p.radices)
+	rad := make([]int, n)
+	for d, r := range p.radices {
+		rad[n-1-d] = r
+	}
+	digits := make([]int, n)
+	for i := range p.perm {
+		v := i
+		for d := range n {
+			digits[d] = v % rad[d]
+			v /= rad[d]
+		}
+		r := 0
+		for d := range n {
+			r = r*rad[d] + digits[d]
+		}
+		p.perm[i] = int32(r)
+	}
+}
+
+// NumBins returns nfft/2 + 1, the number of bins in the Hermitian
+// half-spectrum (DC through Nyquist).
+func (p *Plan) NumBins() int { return p.half + 1 }
+
+// PowerInto writes the real-input power spectrum |X_k|^2 of one nfft-sample
+// frame into dst[0:NumBins]. window, when non-nil, is applied during the load
+// and must be at least nfft long. signal must be at least nfft long.
+func (p *Plan) PowerInto(dst, signal, window []float64) {
+	p.pack(signal, window)
+	p.transform()
+	p.unravelPower(dst)
+}
+
+// pack loads the frame as half complex samples c[j] = x[2j] + i*x[2j+1],
+// applying the window on the way in, and applies the bit-reversal permutation
+// so the transform can run in place.
+func (p *Plan) pack(signal, window []float64) {
+	re, im, br := p.re, p.im, p.perm
+	src := signal[:2*p.half]
+	if window == nil {
+		for j, r := range br {
+			re[r] = src[2*j]
+			im[r] = src[2*j+1]
+		}
+		return
+	}
+	w := window[:2*p.half]
+	for j, r := range br {
+		re[r] = src[2*j] * w[2*j]
+		im[r] = src[2*j+1] * w[2*j+1]
+	}
+}
+
+// transform runs an in-place decimation-in-time complex FFT of size half over
+// the scratch, which pack has already left in digit-reversed order.
+func (p *Plan) transform() {
+	span := 1
+	for _, r := range p.radices {
+		if r == 2 {
+			p.stage2(span)
+		} else {
+			p.stage4(span)
+		}
+		span *= r
+	}
+}
+
+// stage2 applies one radix-2 stage with the given quarter/half span. It only
+// ever runs as the first stage (span 1), where every twiddle is 1, so the
+// complex multiply drops out entirely.
+func (p *Plan) stage2(span int) {
+	re, im := p.re, p.im
+	m := span * 2
+	step := p.half / m
+	for k := 0; k < p.half; k += m {
+		for j := range span {
+			a := k + j
+			b := a + span
+			wr, wi := p.twRe[j*step], p.twIm[j*step]
+			vr := wr*re[b] - wi*im[b]
+			vi := wr*im[b] + wi*re[b]
+			re[b] = re[a] - vr
+			im[b] = im[a] - vi
+			re[a] += vr
+			im[a] += vi
+		}
+	}
+}
+
+// stage4 applies one radix-4 decimation-in-time stage. With A, B, C, D the four
+// twiddled inputs, the forward butterfly (W = exp(-2*pi*i/N)) is
+//
+//	X0 = (A+C) + (B+D)
+//	X1 = (A-C) - i*(B-D)
+//	X2 = (A+C) - (B+D)
+//	X3 = (A-C) + i*(B-D)
+//
+// which is why the two cross terms need no multiply: rotating by -i is a swap
+// of real and imaginary parts with one sign flip.
+func (p *Plan) stage4(span int) {
+	re, im := p.re, p.im
+	m := span * 4
+	step := p.half / m
+	for k := 0; k < p.half; k += m {
+		for j := range span {
+			i0 := k + j
+			i1 := i0 + span
+			i2 := i1 + span
+			i3 := i2 + span
+
+			// A is untwiddled; B, C, D carry W^j, W^2j, W^3j.
+			ar, ai := re[i0], im[i0]
+
+			t := j * step
+			w1r, w1i := p.twRe[t], p.twIm[t]
+			w2r, w2i := p.twRe[2*t], p.twIm[2*t]
+			w3r, w3i := p.twRe[3*t], p.twIm[3*t]
+
+			br := w1r*re[i1] - w1i*im[i1]
+			bi := w1r*im[i1] + w1i*re[i1]
+			cr := w2r*re[i2] - w2i*im[i2]
+			ci := w2r*im[i2] + w2i*re[i2]
+			dr := w3r*re[i3] - w3i*im[i3]
+			di := w3r*im[i3] + w3i*re[i3]
+
+			// t0 = A+C, t1 = A-C, t2 = B+D, t3 = B-D.
+			t0r, t0i := ar+cr, ai+ci
+			t1r, t1i := ar-cr, ai-ci
+			t2r, t2i := br+dr, bi+di
+			t3r, t3i := br-dr, bi-di
+
+			re[i0], im[i0] = t0r+t2r, t0i+t2i
+			re[i2], im[i2] = t0r-t2r, t0i-t2i
+			// -i*(t3r + i*t3i) = t3i - i*t3r
+			re[i1], im[i1] = t1r+t3i, t1i-t3r
+			re[i3], im[i3] = t1r-t3i, t1i+t3r
+		}
+	}
+}
+
+// unravelPower recombines the half-size spectrum into |X_k|^2 for k in
+// [0, half].
+//
+// With C the half-size spectrum, the even and odd half-spectra of the original
+// real sequence are E = (C[k] + conj(C[half-k]))/2 and
+// O = -i*(C[k] - conj(C[half-k]))/2, and X[k] = E + W_N^k * O.
+func (p *Plan) unravelPower(dst []float64) {
+	re, im := p.re, p.im
+	for k := 0; k <= p.half; k++ {
+		// C wraps at half, so k == 0 and k == half both read C[0].
+		ck, cm := 0, 0
+		if k > 0 && k < p.half {
+			ck, cm = k, p.half-k
+		}
+		ckr, cki := re[ck], im[ck]
+		cmr, cmi := re[cm], im[cm]
+
+		er := 0.5 * (ckr + cmr)
+		ei := 0.5 * (cki - cmi)
+		or := 0.5 * (cki + cmi)
+		oi := -0.5 * (ckr - cmr)
+
+		wr, wi := p.unRe[k], p.unIm[k]
+		xr := er + (wr*or - wi*oi)
+		xi := ei + (wr*oi + wi*or)
+		dst[k] = xr*xr + xi*xi
+	}
+}

--- a/internal/fft/fft.go
+++ b/internal/fft/fft.go
@@ -1,12 +1,19 @@
 // Package fft provides the real-input power-spectrum transform used by the sox
 // renderer.
 //
-// It exists because simd's f64.STFTPlan, which this replaces, runs a scalar
-// radix-2 butterfly: on arm64 it accounts for around 61% of a spectrogram
-// render. See github.com/tphakala/simd#192. Once that lands vectorized f64
-// kernels this package should shrink back to a thin call into simd, so the API
-// here is deliberately the minimum the renderer needs (a single frame, no
-// framing or padding modes) rather than a general STFT.
+// It exists because the transform is the renderer's dominant cost and neither
+// available implementation was fast enough: the internal/dsp plan this package
+// displaces ran a full-size complex FFT over real input, and simd's
+// f64.STFTPlan (evaluated at v1.5.0, and the reference these tests still
+// compare against) halves that but leaves the butterfly scalar. Measured on an
+// i7-1260P at nfft=1024, this package is about 1.6x f64.STFTPlan.
+//
+// simd#192 tracks vectorizing that butterfly and adding the f64 kernels this
+// would need; f64 currently exports no ButterflyComplex or RealFFTUnpack at
+// all, so composing simd primitives was not an option for a float64 consumer.
+// Once #192 lands, this package should shrink back to a thin call into simd,
+// so the API here is deliberately the minimum the renderer needs (a single
+// frame, no framing or padding modes) rather than a general STFT.
 //
 // The transform is the standard real-input trick: an nfft-point real sequence
 // is packed into an nfft/2-point complex sequence (evens into the real part,
@@ -16,11 +23,16 @@ package fft
 
 import (
 	"errors"
+	"fmt"
 	"math"
+	"math/bits"
 )
 
-// ErrNotPowerOfTwo is returned when nfft is not a power of two >= 4.
-var ErrNotPowerOfTwo = errors.New("fft: size must be a power of two >= 4")
+// ErrUnsupportedSize is returned by NewPlan when nfft is not a power of two, or
+// is a power of two below 4. It is deliberately not named for the power-of-two
+// condition alone: nfft == 2 is a power of two and is still rejected, because
+// the packed transform needs at least two complex points.
+var ErrUnsupportedSize = errors.New("fft: size must be a power of two >= 4")
 
 // Plan holds the resident twiddle tables and scratch for a fixed transform
 // size. Reuse one across frames to stay allocation-free.
@@ -58,7 +70,7 @@ type Plan struct {
 // must be a power of two and at least 4.
 func NewPlan(nfft int) (*Plan, error) {
 	if nfft < 4 || nfft&(nfft-1) != 0 {
-		return nil, ErrNotPowerOfTwo
+		return nil, ErrUnsupportedSize
 	}
 	half := nfft >> 1
 
@@ -74,10 +86,8 @@ func NewPlan(nfft int) (*Plan, error) {
 		im:   make([]float64, half),
 	}
 
-	logHalf := 0
-	for 1<<logHalf < half {
-		logHalf++
-	}
+	// half is a power of two, so its trailing-zero count is log2(half).
+	logHalf := bits.TrailingZeros(uint(half))
 	if logHalf%2 == 1 {
 		p.radices = append(p.radices, 2)
 	}
@@ -130,14 +140,27 @@ func (p *Plan) buildPerm() {
 	}
 }
 
+// NFFT returns the transform size the plan was built for.
+func (p *Plan) NFFT() int { return p.nfft }
+
 // NumBins returns nfft/2 + 1, the number of bins in the Hermitian
 // half-spectrum (DC through Nyquist).
 func (p *Plan) NumBins() int { return p.half + 1 }
 
 // PowerInto writes the real-input power spectrum |X_k|^2 of one nfft-sample
-// frame into dst[0:NumBins]. window, when non-nil, is applied during the load
-// and must be at least nfft long. signal must be at least nfft long.
+// frame into dst[0:NumBins]. window, when non-nil, is applied during the load.
+//
+// It panics unless len(dst) >= NumBins(), len(signal) >= NFFT(), and, for a
+// non-nil window, len(window) >= NFFT(). The check is explicit because the
+// loads below re-slice these arguments, and a slice expression bound-checks
+// against capacity rather than length: without it, a short slice backed by a
+// larger array would be accepted silently and the transform would read whatever
+// followed it, producing a plausible but wrong spectrum instead of failing.
 func (p *Plan) PowerInto(dst, signal, window []float64) {
+	if len(dst) < p.half+1 || len(signal) < p.nfft || (window != nil && len(window) < p.nfft) {
+		panic(fmt.Sprintf("fft: PowerInto: nfft %d needs dst >= %d, signal >= %d, window >= %d (nil ok); got %d, %d, %d",
+			p.nfft, p.half+1, p.nfft, p.nfft, len(dst), len(signal), len(window)))
+	}
 	p.pack(signal, window)
 	p.transform()
 	p.unravelPower(dst)
@@ -147,19 +170,22 @@ func (p *Plan) PowerInto(dst, signal, window []float64) {
 // applying the window on the way in, and applies the bit-reversal permutation
 // so the transform can run in place.
 func (p *Plan) pack(signal, window []float64) {
-	re, im, br := p.re, p.im, p.perm
-	src := signal[:2*p.half]
+	re, im, br := p.re[:p.half], p.im[:p.half], p.perm
+	src := signal[:2*len(br)]
 	if window == nil {
 		for j, r := range br {
-			re[r] = src[2*j]
-			im[r] = src[2*j+1]
+			s := src[2*j : 2*j+2 : 2*j+2]
+			re[r] = s[0]
+			im[r] = s[1]
 		}
 		return
 	}
-	w := window[:2*p.half]
+	w := window[:2*len(br)]
 	for j, r := range br {
-		re[r] = src[2*j] * w[2*j]
-		im[r] = src[2*j+1] * w[2*j+1]
+		s := src[2*j : 2*j+2 : 2*j+2]
+		ww := w[2*j : 2*j+2 : 2*j+2]
+		re[r] = s[0] * ww[0]
+		im[r] = s[1] * ww[1]
 	}
 }
 
@@ -169,7 +195,12 @@ func (p *Plan) transform() {
 	span := 1
 	for _, r := range p.radices {
 		if r == 2 {
-			// Only ever the first stage; see stage2.
+			// stage2 hardcodes span 1 (see its doc); a radix-2 anywhere but
+			// first would silently produce a wrong transform, so assert rather
+			// than trust the construction in NewPlan.
+			if span != 1 {
+				panic("fft: radix-2 stage at span > 1")
+			}
 			p.stage2()
 		} else {
 			p.stage4(span)
@@ -203,42 +234,43 @@ func (p *Plan) stage2() {
 // which is why the two cross terms need no multiply: rotating by -i is a swap
 // of real and imaginary parts with one sign flip.
 func (p *Plan) stage4(span int) {
-	re, im := p.re, p.im
+	re, im := p.re[:p.half], p.im[:p.half]
 	m := span * 4
 	step := p.half / m
-	for k := 0; k < p.half; k += m {
-		for j := range span {
-			i0 := k + j
-			i1 := i0 + span
-			i2 := i1 + span
-			i3 := i2 + span
-
-			// A is untwiddled; B, C, D carry W^j, W^2j, W^3j.
-			ar, ai := re[i0], im[i0]
+	twRe, twIm := p.twRe[:p.half], p.twIm[:p.half]
+	for k := 0; k+m <= len(re); k += m {
+		r0 := re[k : k+span : k+span]
+		r1 := re[k+span : k+2*span : k+2*span]
+		r2 := re[k+2*span : k+3*span : k+3*span]
+		r3 := re[k+3*span : k+4*span : k+4*span]
+		m0 := im[k : k+span : k+span]
+		m1 := im[k+span : k+2*span : k+2*span]
+		m2 := im[k+2*span : k+3*span : k+3*span]
+		m3 := im[k+3*span : k+4*span : k+4*span]
+		for j := range r0 {
+			ar, ai := r0[j], m0[j]
 
 			t := j * step
-			w1r, w1i := p.twRe[t], p.twIm[t]
-			w2r, w2i := p.twRe[2*t], p.twIm[2*t]
-			w3r, w3i := p.twRe[3*t], p.twIm[3*t]
+			w1r, w1i := twRe[t], twIm[t]
+			w2r, w2i := twRe[2*t], twIm[2*t]
+			w3r, w3i := twRe[3*t], twIm[3*t]
 
-			br := w1r*re[i1] - w1i*im[i1]
-			bi := w1r*im[i1] + w1i*re[i1]
-			cr := w2r*re[i2] - w2i*im[i2]
-			ci := w2r*im[i2] + w2i*re[i2]
-			dr := w3r*re[i3] - w3i*im[i3]
-			di := w3r*im[i3] + w3i*re[i3]
+			br := w1r*r1[j] - w1i*m1[j]
+			bi := w1r*m1[j] + w1i*r1[j]
+			cr := w2r*r2[j] - w2i*m2[j]
+			ci := w2r*m2[j] + w2i*r2[j]
+			dr := w3r*r3[j] - w3i*m3[j]
+			di := w3r*m3[j] + w3i*r3[j]
 
-			// t0 = A+C, t1 = A-C, t2 = B+D, t3 = B-D.
 			t0r, t0i := ar+cr, ai+ci
 			t1r, t1i := ar-cr, ai-ci
 			t2r, t2i := br+dr, bi+di
 			t3r, t3i := br-dr, bi-di
 
-			re[i0], im[i0] = t0r+t2r, t0i+t2i
-			re[i2], im[i2] = t0r-t2r, t0i-t2i
-			// -i*(t3r + i*t3i) = t3i - i*t3r
-			re[i1], im[i1] = t1r+t3i, t1i-t3r
-			re[i3], im[i3] = t1r-t3i, t1i+t3r
+			r0[j], m0[j] = t0r+t2r, t0i+t2i
+			r2[j], m2[j] = t0r-t2r, t0i-t2i
+			r1[j], m1[j] = t1r+t3i, t1i-t3r
+			r3[j], m3[j] = t1r-t3i, t1i+t3r
 		}
 	}
 }
@@ -258,8 +290,10 @@ func (p *Plan) stage4(span int) {
 //
 // with w the unravel twiddle at k and v the one at half-k.
 func (p *Plan) unravelPower(dst []float64) {
-	re, im := p.re, p.im
 	half := p.half
+	re, im := p.re[:half], p.im[:half]
+	unRe, unIm := p.unRe[:half+1], p.unIm[:half+1]
+	dst = dst[:half+1]
 
 	// DC and Nyquist both fold onto C[0] and are purely real.
 	c0r, c0i := re[0], im[0]
@@ -276,12 +310,12 @@ func (p *Plan) unravelPower(dst []float64) {
 		or := 0.5 * (aki + bki)
 		oi := -0.5 * (akr - bkr)
 
-		wr, wi := p.unRe[k], p.unIm[k]
+		wr, wi := unRe[k], unIm[k]
 		xr := er + (wr*or - wi*oi)
 		xi := ei + (wr*oi + wi*or)
 		dst[k] = xr*xr + xi*xi
 
-		vr, vi := p.unRe[m], p.unIm[m]
+		vr, vi := unRe[m], unIm[m]
 		yr := er + (vr*or + vi*oi)
 		yi := -ei - (vr*oi - vi*or)
 		dst[m] = yr*yr + yi*yi
@@ -292,7 +326,7 @@ func (p *Plan) unravelPower(dst []float64) {
 		akr, aki := re[h], im[h]
 		er, ei := akr, 0.0
 		or, oi := aki, 0.0
-		wr, wi := p.unRe[h], p.unIm[h]
+		wr, wi := unRe[h], unIm[h]
 		xr := er + (wr*or - wi*oi)
 		xi := ei + (wr*oi + wi*or)
 		dst[h] = xr*xr + xi*xi

--- a/internal/fft/fft_test.go
+++ b/internal/fft/fft_test.go
@@ -1,0 +1,180 @@
+package fft
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/f64"
+)
+
+// dftSizes are the transform sizes the sox renderer actually uses (YSize
+// 129/257/513/1025 -> dft 256/512/1024/2048), plus the small sizes that
+// exercise the stage-count edge cases.
+var dftSizes = []int{4, 8, 16, 32, 64, 256, 512, 1024, 2048}
+
+// hann returns a symmetric Hann window of length n, matching what the sox
+// analyzer feeds in (makeWindow builds one of length dft+1 and only the first
+// dft entries are read).
+func hann(n int) []float64 {
+	w := make([]float64, n)
+	m := float64(n - 1)
+	for i := range w {
+		w[i] = 0.5 - 0.5*math.Cos(2*math.Pi*float64(i)/m)
+	}
+	return w
+}
+
+func testSignal(n int) []float64 {
+	s := make([]float64, n)
+	for i := range s {
+		t := float64(i) / 24000
+		s[i] = 0.4*math.Sin(2*math.Pi*1000*t) +
+			0.2*math.Sin(2*math.Pi*3500*t) +
+			0.1*math.Sin(2*math.Pi*7000*t)
+	}
+	return s
+}
+
+// referencePower computes the same one-frame power spectrum via simd's
+// f64.STFTPlan, which is the implementation this package replaces and which is
+// already known to render bit-exactly against the SoX binary.
+func referencePower(t *testing.T, nfft int, signal, window []float64) []float64 {
+	t.Helper()
+	ref, err := f64.NewSTFTPlan(nfft)
+	if err != nil {
+		t.Fatalf("simd plan: %v", err)
+	}
+	dst := make([]float64, nfft/2+1)
+	if got := ref.STFTPowerInto(dst, signal, window, nfft, f64.NoPad); got != 1 {
+		t.Fatalf("simd reference wrote %d frames, want 1", got)
+	}
+	return dst
+}
+
+// TestPowerIntoMatchesSIMD is the acceptance test for the vendored transform:
+// it must agree with simd's STFTPowerInto closely enough that no palette index
+// can move. A radix-4 decomposition reorders the arithmetic, so the results are
+// not required to be bit-identical, only to agree to a relative error far below
+// what a 0.775 dB palette step could notice.
+func TestPowerIntoMatchesSIMD(t *testing.T) {
+	const tol = 1e-12
+	for _, nfft := range dftSizes {
+		t.Run(sizeName(nfft), func(t *testing.T) {
+			sig := testSignal(nfft)
+			win := hann(nfft)
+			want := referencePower(t, nfft, sig, win)
+
+			p, err := NewPlan(nfft)
+			if err != nil {
+				t.Fatalf("NewPlan: %v", err)
+			}
+			if p.NumBins() != nfft/2+1 {
+				t.Fatalf("NumBins = %d, want %d", p.NumBins(), nfft/2+1)
+			}
+			got := make([]float64, p.NumBins())
+			p.PowerInto(got, sig, win)
+
+			// Scale the comparison by the spectrum peak: bins in a deep null
+			// carry no energy and their relative error is meaningless.
+			peak := 0.0
+			for _, v := range want {
+				peak = math.Max(peak, v)
+			}
+			for k := range want {
+				if diff := math.Abs(got[k] - want[k]); diff > tol*peak {
+					t.Fatalf("bin %d: got %g, want %g (diff %g > %g)",
+						k, got[k], want[k], diff, tol*peak)
+				}
+			}
+		})
+	}
+}
+
+// TestPowerIntoRectangularWindow covers the nil-window path.
+func TestPowerIntoRectangularWindow(t *testing.T) {
+	const nfft = 256
+	sig := testSignal(nfft)
+	want := referencePower(t, nfft, sig, nil)
+
+	p, err := NewPlan(nfft)
+	if err != nil {
+		t.Fatalf("NewPlan: %v", err)
+	}
+	got := make([]float64, p.NumBins())
+	p.PowerInto(got, sig, nil)
+
+	peak := 0.0
+	for _, v := range want {
+		peak = math.Max(peak, v)
+	}
+	for k := range want {
+		if diff := math.Abs(got[k] - want[k]); diff > 1e-12*peak {
+			t.Fatalf("bin %d: got %g, want %g", k, got[k], want[k])
+		}
+	}
+}
+
+// TestPowerIntoPureTone checks the transform independently of the reference:
+// a bin-centred sinusoid must put essentially all its energy in that one bin.
+func TestPowerIntoPureTone(t *testing.T) {
+	const nfft = 1024
+	const bin = 64
+	sig := make([]float64, nfft)
+	for i := range sig {
+		sig[i] = math.Sin(2 * math.Pi * float64(bin) * float64(i) / float64(nfft))
+	}
+	p, err := NewPlan(nfft)
+	if err != nil {
+		t.Fatalf("NewPlan: %v", err)
+	}
+	got := make([]float64, p.NumBins())
+	p.PowerInto(got, sig, nil)
+
+	peakBin, peak := 0, 0.0
+	for k, v := range got {
+		if v > peak {
+			peak, peakBin = v, k
+		}
+	}
+	if peakBin != bin {
+		t.Fatalf("peak at bin %d, want %d", peakBin, bin)
+	}
+	// Every other bin should be orders of magnitude down.
+	for k, v := range got {
+		if k != bin && v > peak*1e-12 {
+			t.Errorf("bin %d has %g, want << peak %g", k, v, peak)
+		}
+	}
+}
+
+func TestNewPlanRejectsNonPowerOfTwo(t *testing.T) {
+	for _, n := range []int{0, 1, 3, 100, 1000} {
+		if _, err := NewPlan(n); err == nil {
+			t.Errorf("NewPlan(%d): expected an error, got nil", n)
+		}
+	}
+}
+
+func sizeName(n int) string {
+	switch n {
+	case 4:
+		return "nfft4"
+	case 8:
+		return "nfft8"
+	case 16:
+		return "nfft16"
+	case 32:
+		return "nfft32"
+	case 64:
+		return "nfft64"
+	case 256:
+		return "nfft256"
+	case 512:
+		return "nfft512"
+	case 1024:
+		return "nfft1024"
+	case 2048:
+		return "nfft2048"
+	}
+	return "nfft?"
+}

--- a/internal/fft/fft_test.go
+++ b/internal/fft/fft_test.go
@@ -178,3 +178,70 @@ func sizeName(n int) string {
 	}
 	return "nfft?"
 }
+
+// TestPowerIntoWritesEveryBin guards the paired unravel: bins are emitted two
+// at a time with DC, Nyquist and the self-paired middle bin special-cased, so a
+// bin could be skipped without any value comparison noticing. Pre-filling with
+// NaN makes an unwritten bin impossible to miss.
+func TestPowerIntoWritesEveryBin(t *testing.T) {
+	for nfft := 4; nfft <= 4096; nfft <<= 1 {
+		p, err := NewPlan(nfft)
+		if err != nil {
+			t.Fatalf("NewPlan(%d): %v", nfft, err)
+		}
+		dst := make([]float64, p.NumBins())
+		for i := range dst {
+			dst[i] = math.NaN()
+		}
+		p.PowerInto(dst, testSignal(nfft), hann(nfft))
+		for k, v := range dst {
+			if math.IsNaN(v) {
+				t.Errorf("nfft=%d: bin %d was never written", nfft, k)
+			}
+		}
+	}
+}
+
+// TestPowerIntoAllSizes runs the reference comparison across every power of two
+// the plan supports in the useful range, so both radix decompositions
+// ([4,4,...] when log2(half) is even, [2,4,4,...] when odd) are covered at many
+// stage counts rather than only at the four sizes sox happens to use.
+func TestPowerIntoAllSizes(t *testing.T) {
+	for nfft := 4; nfft <= 4096; nfft <<= 1 {
+		sig := testSignal(nfft)
+		win := hann(nfft)
+		want := referencePower(t, nfft, sig, win)
+
+		p, err := NewPlan(nfft)
+		if err != nil {
+			t.Fatalf("NewPlan(%d): %v", nfft, err)
+		}
+		got := make([]float64, p.NumBins())
+		p.PowerInto(got, sig, win)
+
+		peak := 0.0
+		for _, v := range want {
+			peak = math.Max(peak, v)
+		}
+		for k := range want {
+			if diff := math.Abs(got[k] - want[k]); diff > 1e-12*peak {
+				t.Fatalf("nfft=%d bin %d: got %g, want %g (diff %g)",
+					nfft, k, got[k], want[k], diff)
+			}
+		}
+	}
+}
+
+// TestPowerIntoAllocFree keeps the transform off the heap: it runs once per
+// block for every column of every render.
+func TestPowerIntoAllocFree(t *testing.T) {
+	p, err := NewPlan(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, win := testSignal(1024), hann(1024)
+	dst := make([]float64, p.NumBins())
+	if n := testing.AllocsPerRun(100, func() { p.PowerInto(dst, sig, win) }); n != 0 {
+		t.Errorf("PowerInto allocates %v times per call, want 0", n)
+	}
+}

--- a/internal/fft/fft_test.go
+++ b/internal/fft/fft_test.go
@@ -1,16 +1,14 @@
 package fft
 
 import (
+	"errors"
+	"fmt"
 	"math"
+	"math/cmplx"
 	"testing"
 
 	"github.com/tphakala/simd/f64"
 )
-
-// dftSizes are the transform sizes the sox renderer actually uses (YSize
-// 129/257/513/1025 -> dft 256/512/1024/2048), plus the small sizes that
-// exercise the stage-count edge cases.
-var dftSizes = []int{4, 8, 16, 32, 64, 256, 512, 1024, 2048}
 
 // hann returns a symmetric Hann window of length n, matching what the sox
 // analyzer feeds in (makeWindow builds one of length dft+1 and only the first
@@ -36,8 +34,7 @@ func testSignal(n int) []float64 {
 }
 
 // referencePower computes the same one-frame power spectrum via simd's
-// f64.STFTPlan, which is the implementation this package replaces and which is
-// already known to render bit-exactly against the SoX binary.
+// f64.STFTPlan, the implementation this package was measured against.
 func referencePower(t *testing.T, nfft int, signal, window []float64) []float64 {
 	t.Helper()
 	ref, err := f64.NewSTFTPlan(nfft)
@@ -51,40 +48,97 @@ func referencePower(t *testing.T, nfft int, signal, window []float64) []float64 
 	return dst
 }
 
-// TestPowerIntoMatchesSIMD is the acceptance test for the vendored transform:
-// it must agree with simd's STFTPowerInto closely enough that no palette index
-// can move. A radix-4 decomposition reorders the arithmetic, so the results are
-// not required to be bit-identical, only to agree to a relative error far below
-// what a 0.775 dB palette step could notice.
+// naivePower is an independent O(n^2) DFT, written straight from the definition
+// with no shared code path. The differential tests all compare against simd, so
+// a bug in simd would be agreed with unanimously; this is the only ground truth
+// in the package that does not depend on another FFT.
+func naivePower(signal, window []float64, nfft int) []float64 {
+	x := make([]complex128, nfft)
+	for n := range x {
+		v := signal[n]
+		if window != nil {
+			v *= window[n]
+		}
+		x[n] = complex(v, 0)
+	}
+	out := make([]float64, nfft/2+1)
+	for k := range out {
+		var acc complex128
+		for n := 0; n < nfft; n++ {
+			ang := -2 * math.Pi * float64(k) * float64(n) / float64(nfft)
+			acc += x[n] * cmplx.Exp(complex(0, ang))
+		}
+		out[k] = real(acc)*real(acc) + imag(acc)*imag(acc)
+	}
+	return out
+}
+
+// assertClose compares a power spectrum against a reference with a hybrid
+// tolerance.
+//
+// A purely peak-relative bound is close to vacuous: at nfft=2048, 68% of bins
+// sit more than 1e-12 below the peak, so their value is unconstrained and a
+// transform that flushed them to zero would still pass. The per-bin term is
+// what actually constrains those bins; the peak term keeps deep nulls, where
+// relative error is meaningless, from failing on rounding noise.
+func assertClose(t *testing.T, got, want []float64, atolPeak, rtol float64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("length %d, want %d", len(got), len(want))
+	}
+	peak := 0.0
+	for _, v := range want {
+		peak = math.Max(peak, v)
+	}
+	for k := range want {
+		tol := atolPeak*peak + rtol*math.Abs(want[k])
+		if diff := math.Abs(got[k] - want[k]); diff > tol {
+			t.Fatalf("bin %d: got %g, want %g (diff %g > tol %g)", k, got[k], want[k], diff, tol)
+		}
+	}
+}
+
+// TestPowerIntoMatchesSIMD is the acceptance test: the vendored transform must
+// agree with simd's across every size the plan supports, so both decompositions
+// ([4,4,...] when log2(half) is even, [2,4,4,...] when odd) are covered at many
+// stage counts rather than only the four sizes sox uses.
 func TestPowerIntoMatchesSIMD(t *testing.T) {
-	const tol = 1e-12
-	for _, nfft := range dftSizes {
-		t.Run(sizeName(nfft), func(t *testing.T) {
-			sig := testSignal(nfft)
-			win := hann(nfft)
+	for nfft := 4; nfft <= 4096; nfft <<= 1 {
+		t.Run(fmt.Sprintf("nfft%d", nfft), func(t *testing.T) {
+			sig, win := testSignal(nfft), hann(nfft)
 			want := referencePower(t, nfft, sig, win)
 
 			p, err := NewPlan(nfft)
 			if err != nil {
 				t.Fatalf("NewPlan: %v", err)
 			}
-			if p.NumBins() != nfft/2+1 {
-				t.Fatalf("NumBins = %d, want %d", p.NumBins(), nfft/2+1)
+			if p.NumBins() != nfft/2+1 || p.NFFT() != nfft {
+				t.Fatalf("NumBins/NFFT = %d/%d, want %d/%d", p.NumBins(), p.NFFT(), nfft/2+1, nfft)
 			}
 			got := make([]float64, p.NumBins())
 			p.PowerInto(got, sig, win)
+			assertClose(t, got, want, 1e-14, 1e-9)
+		})
+	}
+}
 
-			// Scale the comparison by the spectrum peak: bins in a deep null
-			// carry no energy and their relative error is meaningless.
-			peak := 0.0
-			for _, v := range want {
-				peak = math.Max(peak, v)
-			}
-			for k := range want {
-				if diff := math.Abs(got[k] - want[k]); diff > tol*peak {
-					t.Fatalf("bin %d: got %g, want %g (diff %g > %g)",
-						k, got[k], want[k], diff, tol*peak)
+// TestPowerIntoMatchesNaiveDFT is the reference-independent check. It is
+// quadratic, so it runs only at small sizes, but it covers both radix
+// decompositions and is the only assertion here that would survive simd itself
+// being wrong.
+func TestPowerIntoMatchesNaiveDFT(t *testing.T) {
+	for nfft := 4; nfft <= 256; nfft <<= 1 {
+		t.Run(fmt.Sprintf("nfft%d", nfft), func(t *testing.T) {
+			for _, win := range [][]float64{nil, hann(nfft)} {
+				sig := testSignal(nfft)
+				want := naivePower(sig, win, nfft)
+				p, err := NewPlan(nfft)
+				if err != nil {
+					t.Fatalf("NewPlan: %v", err)
 				}
+				got := make([]float64, p.NumBins())
+				p.PowerInto(got, sig, win)
+				assertClose(t, got, want, 1e-12, 1e-6)
 			}
 		})
 	}
@@ -102,81 +156,54 @@ func TestPowerIntoRectangularWindow(t *testing.T) {
 	}
 	got := make([]float64, p.NumBins())
 	p.PowerInto(got, sig, nil)
-
-	peak := 0.0
-	for _, v := range want {
-		peak = math.Max(peak, v)
-	}
-	for k := range want {
-		if diff := math.Abs(got[k] - want[k]); diff > 1e-12*peak {
-			t.Fatalf("bin %d: got %g, want %g", k, got[k], want[k])
-		}
-	}
+	assertClose(t, got, want, 1e-14, 1e-9)
 }
 
-// TestPowerIntoPureTone checks the transform independently of the reference:
-// a bin-centred sinusoid must put essentially all its energy in that one bin.
-func TestPowerIntoPureTone(t *testing.T) {
+// TestPowerIntoPlanReuse covers the way the renderer actually calls this: one
+// plan, thousands of frames. Every other value test builds a fresh plan and
+// calls once, so stale scratch surviving between calls (a non-bijective
+// permutation, say) would go unnoticed.
+func TestPowerIntoPlanReuse(t *testing.T) {
 	const nfft = 1024
-	const bin = 64
-	sig := make([]float64, nfft)
-	for i := range sig {
-		sig[i] = math.Sin(2 * math.Pi * float64(bin) * float64(i) / float64(nfft))
-	}
 	p, err := NewPlan(nfft)
 	if err != nil {
 		t.Fatalf("NewPlan: %v", err)
 	}
-	got := make([]float64, p.NumBins())
-	p.PowerInto(got, sig, nil)
+	win := hann(nfft)
+	signals := [][]float64{
+		testSignal(nfft),
+		make([]float64, nfft), // silence between two live frames
+		hann(nfft),            // a different shape entirely
+		testSignal(nfft),      // the first signal again: must reproduce exactly
+	}
+	var first []float64
+	for i, sig := range signals {
+		got := make([]float64, p.NumBins())
+		p.PowerInto(got, sig, win)
 
-	peakBin, peak := 0, 0.0
-	for k, v := range got {
-		if v > peak {
-			peak, peakBin = v, k
+		fresh, err := NewPlan(nfft)
+		if err != nil {
+			t.Fatalf("NewPlan: %v", err)
+		}
+		want := make([]float64, fresh.NumBins())
+		fresh.PowerInto(want, sig, win)
+
+		for k := range want {
+			if got[k] != want[k] {
+				t.Fatalf("frame %d bin %d: reused plan gave %g, fresh plan %g", i, k, got[k], want[k])
+			}
+		}
+		if i == 0 {
+			first = got
+		}
+		if i == len(signals)-1 {
+			for k := range first {
+				if got[k] != first[k] {
+					t.Fatalf("bin %d: repeat of frame 0 gave %g, want %g", k, got[k], first[k])
+				}
+			}
 		}
 	}
-	if peakBin != bin {
-		t.Fatalf("peak at bin %d, want %d", peakBin, bin)
-	}
-	// Every other bin should be orders of magnitude down.
-	for k, v := range got {
-		if k != bin && v > peak*1e-12 {
-			t.Errorf("bin %d has %g, want << peak %g", k, v, peak)
-		}
-	}
-}
-
-func TestNewPlanRejectsNonPowerOfTwo(t *testing.T) {
-	for _, n := range []int{0, 1, 3, 100, 1000} {
-		if _, err := NewPlan(n); err == nil {
-			t.Errorf("NewPlan(%d): expected an error, got nil", n)
-		}
-	}
-}
-
-func sizeName(n int) string {
-	switch n {
-	case 4:
-		return "nfft4"
-	case 8:
-		return "nfft8"
-	case 16:
-		return "nfft16"
-	case 32:
-		return "nfft32"
-	case 64:
-		return "nfft64"
-	case 256:
-		return "nfft256"
-	case 512:
-		return "nfft512"
-	case 1024:
-		return "nfft1024"
-	case 2048:
-		return "nfft2048"
-	}
-	return "nfft?"
 }
 
 // TestPowerIntoWritesEveryBin guards the paired unravel: bins are emitted two
@@ -202,32 +229,67 @@ func TestPowerIntoWritesEveryBin(t *testing.T) {
 	}
 }
 
-// TestPowerIntoAllSizes runs the reference comparison across every power of two
-// the plan supports in the useful range, so both radix decompositions
-// ([4,4,...] when log2(half) is even, [2,4,4,...] when odd) are covered at many
-// stage counts rather than only at the four sizes sox happens to use.
-func TestPowerIntoAllSizes(t *testing.T) {
-	for nfft := 4; nfft <= 4096; nfft <<= 1 {
-		sig := testSignal(nfft)
-		win := hann(nfft)
-		want := referencePower(t, nfft, sig, win)
+// TestPowerIntoPureTone checks the transform independently of any reference: a
+// bin-centred sinusoid must put essentially all its energy in that one bin. The
+// bound is tight deliberately; the achieved off-bin leakage is ~1e-29 of the
+// peak, so a loose bound here would pass a badly smeared transform.
+func TestPowerIntoPureTone(t *testing.T) {
+	const nfft = 1024
+	const bin = 64
+	sig := make([]float64, nfft)
+	for i := range sig {
+		sig[i] = math.Sin(2 * math.Pi * float64(bin) * float64(i) / float64(nfft))
+	}
+	p, err := NewPlan(nfft)
+	if err != nil {
+		t.Fatalf("NewPlan: %v", err)
+	}
+	got := make([]float64, p.NumBins())
+	p.PowerInto(got, sig, nil)
 
+	peakBin, peak := 0, 0.0
+	for k, v := range got {
+		if v > peak {
+			peak, peakBin = v, k
+		}
+	}
+	if peakBin != bin {
+		t.Fatalf("peak at bin %d, want %d", peakBin, bin)
+	}
+	for k, v := range got {
+		if k != bin && v > peak*1e-20 {
+			t.Errorf("bin %d has %g, want << peak %g", k, v, peak)
+		}
+	}
+}
+
+// TestPowerIntoParseval asserts energy conservation, a global invariant that no
+// per-bin comparison against another FFT can give: it holds independently of
+// any reference implementation and constrains the low-energy bins that a
+// peak-relative tolerance leaves free.
+func TestPowerIntoParseval(t *testing.T) {
+	for nfft := 4; nfft <= 2048; nfft <<= 1 {
 		p, err := NewPlan(nfft)
 		if err != nil {
 			t.Fatalf("NewPlan(%d): %v", nfft, err)
 		}
+		sig := testSignal(nfft)
 		got := make([]float64, p.NumBins())
-		p.PowerInto(got, sig, win)
+		p.PowerInto(got, sig, nil)
 
-		peak := 0.0
-		for _, v := range want {
-			peak = math.Max(peak, v)
+		var time, freq float64
+		for _, v := range sig {
+			time += v * v
 		}
-		for k := range want {
-			if diff := math.Abs(got[k] - want[k]); diff > 1e-12*peak {
-				t.Fatalf("nfft=%d bin %d: got %g, want %g (diff %g)",
-					nfft, k, got[k], want[k], diff)
-			}
+		// The half-spectrum counts every interior bin once; its mirror supplies
+		// the other half of the energy.
+		freq = got[0] + got[p.NumBins()-1]
+		for k := 1; k < p.NumBins()-1; k++ {
+			freq += 2 * got[k]
+		}
+		freq /= float64(nfft)
+		if rel := math.Abs(freq-time) / math.Max(time, 1e-300); rel > 1e-12 {
+			t.Errorf("nfft=%d: Parseval mismatch, time %g vs freq %g (rel %g)", nfft, time, freq, rel)
 		}
 	}
 }
@@ -244,4 +306,144 @@ func TestPowerIntoAllocFree(t *testing.T) {
 	if n := testing.AllocsPerRun(100, func() { p.PowerInto(dst, sig, win) }); n != 0 {
 		t.Errorf("PowerInto allocates %v times per call, want 0", n)
 	}
+}
+
+func TestNewPlanRejectsUnsupportedSizes(t *testing.T) {
+	// 2 is the interesting one: it IS a power of two and is still rejected,
+	// which is why the sentinel is not named for that condition alone.
+	for _, n := range []int{-4, 0, 1, 2, 3, 100, 1000} {
+		_, err := NewPlan(n)
+		if err == nil {
+			t.Errorf("NewPlan(%d): expected an error, got nil", n)
+			continue
+		}
+		if !errors.Is(err, ErrUnsupportedSize) {
+			t.Errorf("NewPlan(%d): got %v, want ErrUnsupportedSize", n, err)
+		}
+	}
+}
+
+// TestPowerIntoRejectsShortSlices covers the contract that a slice expression
+// alone does not enforce: re-slicing bound-checks against capacity, so a short
+// slice with spare capacity would otherwise be accepted and silently read past
+// its length.
+func TestPowerIntoRejectsShortSlices(t *testing.T) {
+	const nfft = 64
+	p, err := NewPlan(nfft)
+	if err != nil {
+		t.Fatal(err)
+	}
+	full := make([]float64, nfft)
+	win := hann(nfft)
+	bins := make([]float64, p.NumBins())
+
+	cases := []struct {
+		name                string
+		dst, signal, window []float64
+	}{
+		// Each short slice keeps the full backing array, so cap is large and
+		// only the explicit length check can catch it.
+		{"short signal with spare cap", bins, full[:nfft/2], win},
+		{"short window with spare cap", bins, full, win[:nfft/2]},
+		{"short dst with spare cap", bins[:2], full, win},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected a panic, got none")
+				}
+			}()
+			p.PowerInto(c.dst, c.signal, c.window)
+		})
+	}
+}
+
+// FuzzPowerInto asserts the invariants that hold for every in-contract input:
+// no panic, and a power spectrum that is non-negative everywhere. Example
+// tables cover the sizes and one signal shape; this covers the value domain,
+// including the non-finite inputs the renderer can be fed.
+func FuzzPowerInto(f *testing.F) {
+	f.Add(2, uint64(1), false)
+	f.Add(5, uint64(0xdeadbeef), true)
+	f.Add(0, uint64(7), true)
+
+	f.Fuzz(func(t *testing.T, sizeIdx int, seed uint64, useWindow bool) {
+		if sizeIdx < 0 || sizeIdx > 8 {
+			t.Skip()
+		}
+		nfft := 4 << uint(sizeIdx)
+		p, err := NewPlan(nfft)
+		if err != nil {
+			t.Fatalf("NewPlan(%d): %v", nfft, err)
+		}
+
+		// A cheap xorshift keeps the corpus small while still sweeping the
+		// value domain, including the non-finite values sox can encounter.
+		sig := make([]float64, nfft)
+		s := seed | 1
+		for i := range sig {
+			s ^= s << 13
+			s ^= s >> 7
+			s ^= s << 17
+			switch s % 32 {
+			case 0:
+				sig[i] = math.NaN()
+			case 1:
+				sig[i] = math.Inf(1)
+			case 2:
+				sig[i] = math.Inf(-1)
+			default:
+				sig[i] = float64(int64(s%2001)-1000) / 1000
+			}
+		}
+		var win []float64
+		if useWindow {
+			win = hann(nfft)
+		}
+
+		dst := make([]float64, p.NumBins())
+		p.PowerInto(dst, sig, win) // must not panic
+
+		// Non-negativity would be unfalsifiable here: every bin is written as
+		// a*a + b*b. Assert properties that a wrong transform can actually
+		// violate instead.
+		allFinite := true
+		for _, v := range sig {
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				allFinite = false
+				break
+			}
+		}
+		if !allFinite {
+			return // NaN/Inf legitimately propagate; only the no-panic contract applies
+		}
+
+		for k, v := range dst {
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				t.Fatalf("nfft=%d bin %d: finite input produced %g", nfft, k, v)
+			}
+		}
+		if win != nil {
+			return // Parseval below assumes an unwindowed frame
+		}
+		// Parseval: the half-spectrum carries the same energy as the samples,
+		// counting interior bins twice for their mirrored partners. This is a
+		// global invariant, so unlike a per-bin comparison it constrains the
+		// low-energy bins a peak-relative tolerance leaves free.
+		var timeE float64
+		for _, v := range sig {
+			timeE += v * v
+		}
+		freqE := dst[0] + dst[len(dst)-1]
+		for k := 1; k < len(dst)-1; k++ {
+			freqE += 2 * dst[k]
+		}
+		freqE /= float64(nfft)
+		if timeE > 1e-9 {
+			if rel := math.Abs(freqE-timeE) / timeE; rel > 1e-9 {
+				t.Fatalf("nfft=%d: Parseval violated, time %g vs freq %g (rel %g)", nfft, timeE, freqE, rel)
+			}
+		}
+	})
 }

--- a/sox/analyzer.go
+++ b/sox/analyzer.go
@@ -1,8 +1,6 @@
 package sox
 
 import (
-	"math"
-
 	"github.com/tphakala/simd/f64"
 )
 
@@ -21,6 +19,7 @@ type analyzer struct {
 	plan *f64.STFTPlan
 	buf  []float64 // len dftSize
 	pow  []float64 // per-block power spectrum scratch, len rows
+	db   []float64 // per-column dB scratch, len rows
 	mag  []float64 // len rows
 
 	read      int
@@ -49,6 +48,7 @@ func newAnalyzer(dftSize, rows, stepSize, blockSteps int, blockNorm float64, gai
 		plan: plan,
 		buf:  make([]float64, dftSize),
 		pow:  make([]float64, rows),
+		db:   make([]float64, rows),
 		mag:  make([]float64, rows),
 		// Columns are bounded by xSize; pre-size dBfs to avoid repeated grow/copy
 		// in doColumn (cap only, length stays 0 and grows by append).
@@ -124,16 +124,21 @@ func (a *analyzer) doColumn() {
 		return
 	}
 	a.cols++
-	for i := 0; i < a.rows; i++ {
-		dBfs := 10 * math.Log10(a.mag[i]*a.blockNorm)
-		a.dBfs = append(a.dBfs, float32(dBfs+float64(a.gain)))
+	// dBfs = 10*log10(mag*blockNorm), vectorized over the whole column: the
+	// scalar form calls math.Log10 once per cell, which is over half a million
+	// calls for a default-sized image.
+	f64.Scale(a.db, a.mag, a.blockNorm)
+	f64.Log10(a.db, a.db)
+	f64.Scale(a.db, a.db, 10)
+
+	gain := float64(a.gain)
+	for _, dBfs := range a.db {
+		a.dBfs = append(a.dBfs, float32(dBfs+gain))
 		if dBfs > a.max {
 			a.max = dBfs
 		}
 	}
-	for i := range a.mag {
-		a.mag[i] = 0
-	}
+	clear(a.mag)
 	a.blockNum = 0
 }
 

--- a/sox/analyzer.go
+++ b/sox/analyzer.go
@@ -45,12 +45,21 @@ func newAnalyzer(dftSize, rows, stepSize, blockSteps int, blockNorm float64, gai
 		return nil, err
 	}
 	// deriveDFTSize always returns rows == dftSize/2+1, which is exactly the
-	// plan's bin count. Assert it: STFTPowerInto writes whole frames only, so a
-	// destination shorter than NumBins would silently write nothing at all
-	// rather than failing, and every column would come out as digital silence.
+	// plan's bin count. Assert it anyway: rows sizes every per-column buffer
+	// here, and the simd reductions in doColumn silently process only
+	// min(len(dst), len(src)) elements, so a mismatch would quietly truncate
+	// each column rather than fail.
 	if rows != plan.NumBins() {
 		return nil, fmt.Errorf("sox: rows %d does not match DFT bin count %d for size %d",
 			rows, plan.NumBins(), dftSize)
+	}
+	// The window is sliced to dftSize on every block, so check it once here
+	// rather than panicking in the hot loop. Check the shape too, not just the
+	// length: makeWindow derives the taper from ws.dftSize, so a state built
+	// for a larger size is long enough to pass a length check while producing
+	// the wrong window.
+	if ws == nil || ws.dftSize != dftSize || len(ws.window) < dftSize {
+		return nil, fmt.Errorf("sox: window state is not sized for DFT size %d", dftSize)
 	}
 	a := &analyzer{
 		dftSize: dftSize, rows: rows,
@@ -88,9 +97,8 @@ func (a *analyzer) flow(in []float32) {
 			copy(a.buf[:a.dftSize-a.stepSize], a.buf[a.stepSize:a.dftSize])
 			a.read = 0
 		}
-		// Fill in bulk. The per-sample form re-derived the destination index and
-		// paid two bounds checks on every sample, and this loop sees every input
-		// sample in the clip.
+		// Fill in bulk: this loop sees every sample in the clip, so the copy is
+		// shaped to keep the compiler's bounds checks out of it.
 		if k := min(n-idx, a.stepSize-a.read); k > 0 {
 			src := in[idx : idx+k]
 			dst := a.buf[a.dftSize-a.stepSize+a.read:]
@@ -120,13 +128,12 @@ func (a *analyzer) processBlock() {
 		a.lastEnd = a.end
 	}
 	// One frame: the fused real-input transform windows, transforms, and squares
-	// in a single pass, at half the complex FFT size. SoX's own lsx_rdft is
-	// double precision, so staying in float64 here also drops the float32
-	// round-trip the previous complex64 FFT imposed.
+	// in a single pass, at half the complex FFT size. It runs in float64 to
+	// match SoX's own double-precision lsx_rdft.
 	//
-	// pow[k] is |X_k|^2 for k in [0, dftSize/2]. At DC and Nyquist the imaginary
-	// part of a real-input transform is exactly zero, so those bins agree with
-	// SoX's real-only accumulation without a special case.
+	// pow[k] is |X_k|^2 for k in [0, dftSize/2]. DC and Nyquist are purely real
+	// for a real-input transform, so they agree with SoX's real-only
+	// accumulation at those two bins.
 	a.plan.PowerInto(a.pow, a.buf, a.ws.window)
 	f64.Add(a.mag, a.mag, a.pow)
 
@@ -143,15 +150,15 @@ func (a *analyzer) doColumn() {
 		return
 	}
 	a.cols++
-	// dBfs = 10*log10(mag*blockNorm), vectorized over the whole column: the
-	// scalar form calls math.Log10 once per cell, which is over half a million
-	// calls for a default-sized image.
+	// dBfs = 10*log10(mag*blockNorm), vectorized over the whole column: a
+	// per-cell math.Log10 would be over half a million calls for a
+	// default-sized image.
 	f64.Scale(a.db, a.mag, a.blockNorm)
 	f64.Log10(a.db, a.db)
 	f64.Scale(a.db, a.db, 10)
 
 	gain := float64(a.gain)
-	for _, dBfs := range a.db {
+	for _, dBfs := range a.db[:a.rows] {
 		a.dBfs = append(a.dBfs, float32(dBfs+gain))
 		if dBfs > a.max {
 			a.max = dBfs

--- a/sox/analyzer.go
+++ b/sox/analyzer.go
@@ -3,6 +3,7 @@ package sox
 import (
 	"fmt"
 
+	"github.com/tphakala/go-spectrogram/internal/fft"
 	"github.com/tphakala/simd/f64"
 )
 
@@ -18,7 +19,7 @@ type analyzer struct {
 	ws                   *windowState
 	xSize                int
 
-	plan *f64.STFTPlan
+	plan *fft.Plan
 	buf  []float64 // len dftSize
 	pow  []float64 // per-block power spectrum scratch, len rows
 	db   []float64 // per-column dB scratch, len rows
@@ -39,7 +40,7 @@ type analyzer struct {
 func newAnalyzer(dftSize, rows, stepSize, blockSteps int, blockNorm float64, gain, dBRange int, ws *windowState, xSize int) (*analyzer, error) {
 	// dftSize is a power of two by construction (validate() rejects YSize values
 	// that do not yield one), so this only fails on a programming error.
-	plan, err := f64.NewSTFTPlan(dftSize)
+	plan, err := fft.NewPlan(dftSize)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +127,7 @@ func (a *analyzer) processBlock() {
 	// pow[k] is |X_k|^2 for k in [0, dftSize/2]. At DC and Nyquist the imaginary
 	// part of a real-input transform is exactly zero, so those bins agree with
 	// SoX's real-only accumulation without a special case.
-	a.plan.STFTPowerInto(a.pow, a.buf, a.ws.window, a.dftSize, f64.NoPad)
+	a.plan.PowerInto(a.pow, a.buf, a.ws.window)
 	f64.Add(a.mag, a.mag, a.pow)
 
 	a.blockNum++

--- a/sox/analyzer.go
+++ b/sox/analyzer.go
@@ -87,11 +87,19 @@ func (a *analyzer) flow(in []float32) {
 			copy(a.buf[:a.dftSize-a.stepSize], a.buf[a.stepSize:a.dftSize])
 			a.read = 0
 		}
-		for idx < n && a.read < a.stepSize {
-			a.buf[a.dftSize-a.stepSize+a.read] = float64(in[idx])
-			idx++
-			a.read++
-			a.end--
+		// Fill in bulk. The per-sample form re-derived the destination index and
+		// paid two bounds checks on every sample, and this loop sees every input
+		// sample in the clip.
+		if k := min(n-idx, a.stepSize-a.read); k > 0 {
+			src := in[idx : idx+k]
+			dst := a.buf[a.dftSize-a.stepSize+a.read:]
+			dst = dst[:len(src)] // BCE hint: dst[i] is provably in range below
+			for i, v := range src {
+				dst[i] = float64(v)
+			}
+			idx += k
+			a.read += k
+			a.end -= k
 		}
 		if a.read != a.stepSize {
 			break

--- a/sox/analyzer.go
+++ b/sox/analyzer.go
@@ -3,7 +3,7 @@ package sox
 import (
 	"math"
 
-	"github.com/tphakala/go-spectrogram/internal/dsp"
+	"github.com/tphakala/simd/f64"
 )
 
 // analyzer reproduces SoX's streaming spectrogram accumulation. dBfs is stored
@@ -18,10 +18,10 @@ type analyzer struct {
 	ws                   *windowState
 	xSize                int
 
-	plan *dsp.FFTPlan
-	buf  []float64   // len dftSize
-	cin  []complex64 // FFT input scratch, len dftSize
-	mag  []float64   // len rows
+	plan *f64.STFTPlan
+	buf  []float64 // len dftSize
+	pow  []float64 // per-block power spectrum scratch, len rows
+	mag  []float64 // len rows
 
 	read      int
 	end       int
@@ -35,14 +35,20 @@ type analyzer struct {
 	max  float64
 }
 
-func newAnalyzer(dftSize, rows, stepSize, blockSteps int, blockNorm float64, gain, dBRange int, ws *windowState, xSize int) *analyzer {
+func newAnalyzer(dftSize, rows, stepSize, blockSteps int, blockNorm float64, gain, dBRange int, ws *windowState, xSize int) (*analyzer, error) {
+	// dftSize is a power of two by construction (validate() rejects YSize values
+	// that do not yield one), so this only fails on a programming error.
+	plan, err := f64.NewSTFTPlan(dftSize)
+	if err != nil {
+		return nil, err
+	}
 	a := &analyzer{
 		dftSize: dftSize, rows: rows,
 		stepSize: stepSize, blockSteps: blockSteps, blockNorm: blockNorm,
 		gain: gain, dBRange: dBRange, ws: ws, xSize: xSize,
-		plan: dsp.NewFFTPlan(dftSize),
+		plan: plan,
 		buf:  make([]float64, dftSize),
-		cin:  make([]complex64, dftSize),
+		pow:  make([]float64, rows),
 		mag:  make([]float64, rows),
 		// Columns are bounded by xSize; pre-size dBfs to avoid repeated grow/copy
 		// in doColumn (cap only, length stays 0 and grows by append).
@@ -53,7 +59,7 @@ func newAnalyzer(dftSize, rows, stepSize, blockSteps int, blockNorm float64, gai
 	a.lastEnd = 0                     // make_window(p, 0) already done before loop
 	a.max = -float64(dBRange)         // spectrogram.c:443
 	a.read = (stepSize - dftSize) / 2 // spectrogram.c:444 (negative)
-	return a
+	return a, nil
 }
 
 // run feeds all samples then drains, returning the number of columns produced.
@@ -94,16 +100,16 @@ func (a *analyzer) processBlock() {
 		makeWindow(a.ws, a.end)
 		a.lastEnd = a.end
 	}
-	for i := 0; i < a.dftSize; i++ {
-		a.cin[i] = complex(float32(a.buf[i]*a.ws.window[i]), 0)
-	}
-	spec := a.plan.Forward(a.cin)
-	half := a.dftSize >> 1
-	a.mag[0] += sq(float64(real(spec[0])))
-	for i := 1; i < half; i++ {
-		a.mag[i] += sq(float64(real(spec[i]))) + sq(float64(imag(spec[i])))
-	}
-	a.mag[half] += sq(float64(real(spec[half])))
+	// One frame: the fused real-input transform windows, transforms, and squares
+	// in a single pass, at half the complex FFT size. SoX's own lsx_rdft is
+	// double precision, so staying in float64 here also drops the float32
+	// round-trip the previous complex64 FFT imposed.
+	//
+	// pow[k] is |X_k|^2 for k in [0, dftSize/2]. At DC and Nyquist the imaginary
+	// part of a real-input transform is exactly zero, so those bins agree with
+	// SoX's real-only accumulation without a special case.
+	a.plan.STFTPowerInto(a.pow, a.buf, a.ws.window, a.dftSize, f64.NoPad)
+	f64.Add(a.mag, a.mag, a.pow)
 
 	a.blockNum++
 	if a.blockNum == a.blockSteps {
@@ -149,5 +155,3 @@ func (a *analyzer) drain() {
 		a.doColumn()
 	}
 }
-
-func sq(x float64) float64 { return x * x }

--- a/sox/analyzer.go
+++ b/sox/analyzer.go
@@ -1,6 +1,8 @@
 package sox
 
 import (
+	"fmt"
+
 	"github.com/tphakala/simd/f64"
 )
 
@@ -40,6 +42,14 @@ func newAnalyzer(dftSize, rows, stepSize, blockSteps int, blockNorm float64, gai
 	plan, err := f64.NewSTFTPlan(dftSize)
 	if err != nil {
 		return nil, err
+	}
+	// deriveDFTSize always returns rows == dftSize/2+1, which is exactly the
+	// plan's bin count. Assert it: STFTPowerInto writes whole frames only, so a
+	// destination shorter than NumBins would silently write nothing at all
+	// rather than failing, and every column would come out as digital silence.
+	if rows != plan.NumBins() {
+		return nil, fmt.Errorf("sox: rows %d does not match DFT bin count %d for size %d",
+			rows, plan.NumBins(), dftSize)
 	}
 	a := &analyzer{
 		dftSize: dftSize, rows: rows,

--- a/sox/analyzer_test.go
+++ b/sox/analyzer_test.go
@@ -69,8 +69,9 @@ func TestAnalyzerColumnCountMatchesGeometry(t *testing.T) {
 }
 
 // TestNewAnalyzerRejectsBinMismatch guards the invariant that rows equals the
-// DFT bin count. STFTPowerInto writes only whole frames, so a short destination
-// would quietly produce no output instead of an error.
+// DFT bin count. rows sizes every per-column buffer, and the simd reductions in
+// doColumn process only min(len(dst), len(src)) elements, so a mismatch would
+// quietly truncate each column rather than fail.
 func TestNewAnalyzerRejectsBinMismatch(t *testing.T) {
 	ws := newWindowState(1024, WindowHann)
 	makeWindow(ws, 0)

--- a/sox/analyzer_test.go
+++ b/sox/analyzer_test.go
@@ -67,3 +67,17 @@ func TestAnalyzerColumnCountMatchesGeometry(t *testing.T) {
 		t.Errorf("cols %d not within 2 of expected %d", cols, exp)
 	}
 }
+
+// TestNewAnalyzerRejectsBinMismatch guards the invariant that rows equals the
+// DFT bin count. STFTPowerInto writes only whole frames, so a short destination
+// would quietly produce no output instead of an error.
+func TestNewAnalyzerRejectsBinMismatch(t *testing.T) {
+	ws := newWindowState(1024, WindowHann)
+	makeWindow(ws, 0)
+	if _, err := newAnalyzer(1024, 512, 256, 1, 1, 0, 120, ws, 100); err == nil {
+		t.Fatal("expected an error when rows != dftSize/2+1, got nil")
+	}
+	if _, err := newAnalyzer(1024, 513, 256, 1, 1, 0, 120, ws, 100); err != nil {
+		t.Fatalf("expected the correct bin count to be accepted, got %v", err)
+	}
+}

--- a/sox/analyzer_test.go
+++ b/sox/analyzer_test.go
@@ -22,7 +22,10 @@ func TestAnalyzerToneConcentratesEnergy(t *testing.T) {
 	actual := makeWindow(ws, 0)
 	step, blocks, norm := stepSizing(actual, dft, rate, pps, opt.SlackOverlap)
 
-	a := newAnalyzer(dft, rows, step, blocks, norm, -opt.Gain, opt.DBRange, ws, xSize)
+	a, err := newAnalyzer(dft, rows, step, blocks, norm, -opt.Gain, opt.DBRange, ws, xSize)
+	if err != nil {
+		t.Fatal(err)
+	}
 	cols := a.run(sig)
 	if cols == 0 {
 		t.Fatal("no columns produced")
@@ -50,7 +53,10 @@ func TestAnalyzerColumnCountMatchesGeometry(t *testing.T) {
 	ws := newWindowState(dft, opt.Window)
 	actual := makeWindow(ws, 0)
 	step, blocks, norm := stepSizing(actual, dft, rate, pps, opt.SlackOverlap)
-	a := newAnalyzer(dft, rows, step, blocks, norm, -opt.Gain, opt.DBRange, ws, xSize)
+	a, err := newAnalyzer(dft, rows, step, blocks, norm, -opt.Gain, opt.DBRange, ws, xSize)
+	if err != nil {
+		t.Fatal(err)
+	}
 	cols := a.run(sig)
 	// Expected columns ~ rate*dur / (step*blocks); never exceeds xSize.
 	exp := int(rate * dur / float64(step*blocks))

--- a/sox/edge_test.go
+++ b/sox/edge_test.go
@@ -1,0 +1,70 @@
+package sox
+
+import (
+	"math"
+	"testing"
+)
+
+// Edge cases the parity sweep does not cover: degenerate lengths, silence,
+// dynamic-range extremes, autogain, and non-finite samples. These assert the
+// renderer stays in bounds and does not panic, not that it matches SoX.
+func TestRenderEdgeCases(t *testing.T) {
+	cases := []struct {
+		name    string
+		samples []float32
+		opt     Options
+	}{
+		{"shorter-than-one-dft", make([]float32, 100), Options{XSize: 258, YSize: 129}},
+		{"exactly-one-sample", make([]float32, 1), Options{XSize: 258, YSize: 129}},
+		{"all-silence-15s", make([]float32, 15*24000), Options{XSize: 1026, YSize: 513}},
+		{"dbrange-min", benchSignal(24000, 24000), Options{XSize: 258, YSize: 129, DBRange: 20}},
+		{"dbrange-max", benchSignal(24000, 24000), Options{XSize: 258, YSize: 129, DBRange: 180}},
+		{"normalize", benchSignal(24000, 24000), Options{XSize: 258, YSize: 129, Normalize: true}},
+		{"normalize-silence", make([]float32, 24000), Options{XSize: 258, YSize: 129, Normalize: true}},
+		{"raw-offsets", benchSignal(24000, 24000), Options{XSize: 514, YSize: 257, Raw: true}},
+		{"non-multiple-of-tile", benchSignal(24000, 24000), Options{XSize: 517, YSize: 129}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			img, err := Render(c.samples, 24000, c.opt)
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			if img == nil {
+				t.Fatal("nil image")
+			}
+			b := img.Bounds()
+			if b.Dx() <= 0 || b.Dy() <= 0 {
+				t.Fatalf("degenerate bounds %v", b)
+			}
+			for i, p := range img.Pix {
+				if int(p) >= len(img.Palette) {
+					t.Fatalf("pixel %d index %d out of palette range %d", i, p, len(img.Palette))
+				}
+			}
+		})
+	}
+}
+
+func TestRenderNaNInf(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		v    float32
+	}{{"nan", float32(math.NaN())}, {"posinf", float32(math.Inf(1))}, {"neginf", float32(math.Inf(-1))}} {
+		t.Run(c.name, func(t *testing.T) {
+			s := benchSignal(24000, 24000)
+			for i := 0; i < len(s); i += 977 {
+				s[i] = c.v
+			}
+			img, err := Render(s, 24000, Options{XSize: 258, YSize: 129})
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			for i, p := range img.Pix {
+				if int(p) >= len(img.Palette) {
+					t.Fatalf("pixel %d index %d out of palette range %d", i, p, len(img.Palette))
+				}
+			}
+		})
+	}
+}

--- a/sox/edge_test.go
+++ b/sox/edge_test.go
@@ -1,70 +1,283 @@
 package sox
 
 import (
+	"image"
+	"image/png"
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
-// Edge cases the parity sweep does not cover: degenerate lengths, silence,
-// dynamic-range extremes, autogain, and non-finite samples. These assert the
-// renderer stays in bounds and does not panic, not that it matches SoX.
+// paletteHistogram counts how many pixels carry each palette index.
+func paletteHistogram(img *image.Paletted) map[uint8]int {
+	h := make(map[uint8]int)
+	for _, p := range img.Pix {
+		h[p]++
+	}
+	return h
+}
+
+// checkInPalette is the liveness floor: no pixel may index outside the palette.
+func checkInPalette(t *testing.T, img *image.Paletted) {
+	t.Helper()
+	for i, p := range img.Pix {
+		if int(p) >= len(img.Palette) {
+			t.Fatalf("pixel %d index %d out of palette range %d", i, p, len(img.Palette))
+		}
+	}
+}
+
+// Edge cases the SoX parity sweep cannot reach, because they are inputs the
+// binary cannot be handed identically (non-finite samples) or degenerate
+// lengths. Parity now covers the dynamic-range extremes and the ragged tile
+// width pixel-exactly, so this file only carries what parity cannot.
+//
+// These assert image CONTENT, not merely absence of a panic. An earlier version
+// checked only that indices were within the palette, which fires on 1 of 256
+// byte values and let both a halved-palette mutation and a vertically mirrored
+// raster pass unnoticed.
 func TestRenderEdgeCases(t *testing.T) {
+	const rate = 24000
 	cases := []struct {
 		name    string
 		samples []float32
 		opt     Options
+		// wantUniform is true when a correct render is essentially one flat
+		// colour, because digital silence has no signal anywhere.
+		wantUniform bool
 	}{
-		{"shorter-than-one-dft", make([]float32, 100), Options{XSize: 258, YSize: 129}},
-		{"exactly-one-sample", make([]float32, 1), Options{XSize: 258, YSize: 129}},
-		{"all-silence-15s", make([]float32, 15*24000), Options{XSize: 1026, YSize: 513}},
-		{"dbrange-min", benchSignal(24000, 24000), Options{XSize: 258, YSize: 129, DBRange: 20}},
-		{"dbrange-max", benchSignal(24000, 24000), Options{XSize: 258, YSize: 129, DBRange: 180}},
-		{"normalize", benchSignal(24000, 24000), Options{XSize: 258, YSize: 129, Normalize: true}},
-		{"normalize-silence", make([]float32, 24000), Options{XSize: 258, YSize: 129, Normalize: true}},
-		{"raw-offsets", benchSignal(24000, 24000), Options{XSize: 514, YSize: 257, Raw: true}},
-		{"non-multiple-of-tile", benchSignal(24000, 24000), Options{XSize: 517, YSize: 129}},
+		{"shorter-than-one-dft", make([]float32, 100), Options{XSize: 258, YSize: 129}, true},
+		{"exactly-one-sample", make([]float32, 1), Options{XSize: 258, YSize: 129}, true},
+		{"all-silence-15s", make([]float32, 15*rate), Options{XSize: 1026, YSize: 513}, true},
+		{"silence-normalized", make([]float32, rate), Options{XSize: 258, YSize: 129, Normalize: true}, true},
+		{"tone-dbrange-min", benchSignal(rate, rate), Options{XSize: 258, YSize: 129, DBRange: 20}, false},
+		{"tone-dbrange-max", benchSignal(rate, rate), Options{XSize: 258, YSize: 129, DBRange: 180}, false},
+		{"tone-normalized", benchSignal(rate, rate), Options{XSize: 258, YSize: 129, Normalize: true}, false},
+		{"tone-raw", benchSignal(rate, rate), Options{XSize: 514, YSize: 257, Raw: true}, false},
+		{"tone-ragged-width", benchSignal(rate, rate), Options{XSize: 517, YSize: 129}, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			img, err := Render(c.samples, 24000, c.opt)
+			img, err := Render(c.samples, rate, c.opt)
 			if err != nil {
 				t.Fatalf("Render: %v", err)
 			}
-			if img == nil {
-				t.Fatal("nil image")
-			}
+			checkInPalette(t, img)
+
 			b := img.Bounds()
-			if b.Dx() <= 0 || b.Dy() <= 0 {
-				t.Fatalf("degenerate bounds %v", b)
-			}
-			for i, p := range img.Pix {
-				if int(p) >= len(img.Palette) {
-					t.Fatalf("pixel %d index %d out of palette range %d", i, p, len(img.Palette))
+			switch {
+			case c.opt.Raw:
+				// Raw output is exactly the raster: one row per DFT bin.
+				// Asserting the height exactly catches a geometry regression
+				// that a "> 0" check would not.
+				if b.Dy() != c.opt.YSize {
+					t.Errorf("raw height %d, want YSize %d", b.Dy(), c.opt.YSize)
 				}
+				if b.Dx() <= 0 || b.Dx() > c.opt.XSize {
+					t.Errorf("raw width %d, want 1..%d", b.Dx(), c.opt.XSize)
+				}
+			default:
+				// XSize is an upper bound on the raster width, not a fixed
+				// width: a clip shorter than the DFT yields fewer columns and
+				// a correspondingly narrower image. The height is fixed
+				// though, so chrome must always add rows above YSize.
+				if b.Dy() <= c.opt.YSize {
+					t.Errorf("height %d does not enclose a %d-row raster plus chrome",
+						b.Dy(), c.opt.YSize)
+				}
+				if b.Dx() <= 0 {
+					t.Errorf("width %d, want > 0", b.Dx())
+				}
+			}
+
+			hist := paletteHistogram(img)
+			if c.wantUniform {
+				// Silence renders as the floor colour everywhere. With chrome
+				// the axes contribute their own indices, so require one
+				// dominant index rather than literally one.
+				top := 0
+				for _, n := range hist {
+					if n > top {
+						top = n
+					}
+				}
+				if frac := float64(top) / float64(len(img.Pix)); frac < 0.5 {
+					t.Errorf("silence: most common palette index covers only %.1f%% of the image, want a flat render", frac*100)
+				}
+			} else if len(hist) < 3 {
+				// A signal-bearing render must show structure. This is what
+				// catches a raster collapsed to a single colour, which the old
+				// palette-range assertion accepted without complaint.
+				t.Errorf("signal render uses only %d palette indices, want a non-uniform raster", len(hist))
 			}
 		})
 	}
 }
 
+// TestRenderToneLandsAtExpectedRow pins the frequency-axis orientation. SoX puts
+// DC at the bottom row and Nyquist at the top, so a single tone must brighten
+// one specific row. A vertically mirrored raster still produces a plausible
+// image with a plausible palette histogram and passes every other test here;
+// this is the assertion that fails it.
+func TestRenderToneLandsAtExpectedRow(t *testing.T) {
+	const (
+		rate = 24000
+		tone = 3000.0
+		ys   = 129
+	)
+	sig := make([]float32, 2*rate)
+	for i := range sig {
+		sig[i] = float32(0.5 * math.Sin(2*math.Pi*tone*float64(i)/rate))
+	}
+	img, err := Render(sig, rate, Options{XSize: 258, YSize: ys, Raw: true})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	b := img.Bounds()
+	if b.Dy() != ys {
+		t.Fatalf("height %d, want %d", b.Dy(), ys)
+	}
+
+	// Find the brightest row in a column near the middle of the image.
+	x := b.Min.X + b.Dx()/2
+	bright, brightY := -1, -1
+	for y := b.Min.Y; y < b.Max.Y; y++ {
+		if v := int(img.ColorIndexAt(x, y)); v > bright {
+			bright, brightY = v, y
+		}
+	}
+
+	// Raster row 0 is DC and the image is stored top-down with DC at the
+	// bottom, so the tone's bin counts up from the bottom edge.
+	binsPerHz := float64(ys-1) / (rate / 2.0)
+	wantFromBottom := int(math.Round(tone * binsPerHz))
+	wantY := b.Max.Y - 1 - wantFromBottom
+	if d := brightY - wantY; d < -2 || d > 2 {
+		t.Errorf("tone at %.0f Hz brightened row y=%d, want y=%d (+/-2); "+
+			"a mismatch this large means the frequency axis is flipped or shifted",
+			tone, brightY, wantY)
+	}
+}
+
 func TestRenderNaNInf(t *testing.T) {
+	const rate = 24000
 	for _, c := range []struct {
 		name string
 		v    float32
-	}{{"nan", float32(math.NaN())}, {"posinf", float32(math.Inf(1))}, {"neginf", float32(math.Inf(-1))}} {
+	}{
+		{"nan", float32(math.NaN())},
+		{"posinf", float32(math.Inf(1))},
+		{"neginf", float32(math.Inf(-1))},
+	} {
 		t.Run(c.name, func(t *testing.T) {
-			s := benchSignal(24000, 24000)
+			s := benchSignal(rate, rate)
 			for i := 0; i < len(s); i += 977 {
 				s[i] = c.v
 			}
-			img, err := Render(s, 24000, Options{XSize: 258, YSize: 129})
+			img, err := Render(s, rate, Options{XSize: 258, YSize: 129})
 			if err != nil {
 				t.Fatalf("Render: %v", err)
 			}
-			for i, p := range img.Pix {
-				if int(p) >= len(img.Palette) {
-					t.Fatalf("pixel %d index %d out of palette range %d", i, p, len(img.Palette))
-				}
-			}
+			// Non-finite input must not escape as an out-of-palette index; the
+			// dB path maps NaN to the floor colour rather than int(NaN).
+			checkInPalette(t, img)
 		})
+	}
+}
+
+// TestRenderNormalizeWithNonFinite combines two options the table above
+// exercises only separately: with Normalize on, a non-finite sample can reach
+// the auto-gain reference itself.
+func TestRenderNormalizeWithNonFinite(t *testing.T) {
+	const rate = 24000
+	s := benchSignal(rate, rate)
+	for i := 0; i < len(s); i += 501 {
+		s[i] = float32(math.Inf(1))
+	}
+	img, err := Render(s, rate, Options{XSize: 258, YSize: 129, Normalize: true})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	checkInPalette(t, img)
+}
+
+// TestWritePNGIsAtomic covers the publish contract: the destination either does
+// not exist or holds a complete PNG, and no temporary file is left behind.
+func TestWritePNGIsAtomic(t *testing.T) {
+	const rate = 24000
+	dir := t.TempDir()
+	out := filepath.Join(dir, "spec.png")
+
+	if err := WritePNG(out, benchSignal(rate, rate), rate, Options{XSize: 258, YSize: 129}); err != nil {
+		t.Fatalf("WritePNG: %v", err)
+	}
+
+	// The written file must decode as a complete image, not a truncated one.
+	f, err := os.Open(out)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	}()
+	if _, err := png.Decode(f); err != nil {
+		t.Fatalf("decode written PNG: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "spec.png" {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("directory holds %v, want only spec.png (a leftover temp file means the rename path is wrong)", names)
+	}
+}
+
+// TestWritePNGFailureLeavesNoFile covers the error path: a render that cannot be
+// encoded must not publish anything at the destination.
+func TestWritePNGFailureLeavesNoFile(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "spec.png")
+
+	// Zero columns yields a zero-width image, which the PNG encoder rejects.
+	err := WritePNG(out, nil, 24000, Options{XSize: 258, YSize: 129, Raw: true})
+	if err == nil {
+		t.Fatal("expected an encode error for a zero-width image, got nil")
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf("destination exists after a failed write (stat err %v), want no file", statErr)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("temp files left behind: %d entries", len(entries))
+	}
+}
+
+// TestWritePNGFileMode pins the permissions of the published file. Writing via
+// os.CreateTemp and renaming is the correct way to publish atomically, but
+// CreateTemp makes the file 0600 where the os.Create it replaced produced
+// 0666&^umask; a consumer serving these files as another user would break.
+func TestWritePNGFileMode(t *testing.T) {
+	const rate = 24000
+	out := filepath.Join(t.TempDir(), "spec.png")
+	if err := WritePNG(out, benchSignal(rate, rate), rate, Options{XSize: 258, YSize: 129}); err != nil {
+		t.Fatalf("WritePNG: %v", err)
+	}
+	fi, err := os.Stat(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got&0o044 == 0 {
+		t.Errorf("mode %04o is not group/world readable; a consumer running as another user cannot serve it", got)
 	}
 }

--- a/sox/palette.go
+++ b/sox/palette.go
@@ -19,22 +19,28 @@ func spectrumPoints(o Options) int {
 
 // colourIndex ports spectrogram.c:576-581. x is a dBFS value.
 func colourIndex(o Options, x float64) int {
+	return colourIndexAt(x, spectrumPoints(o), float64(o.DBRange))
+}
+
+// colourIndexAt is colourIndex with the two Options-derived constants already
+// resolved. The raster loop calls this once per pixel (over half a million
+// times for the default size), where passing Options by value and recomputing
+// spectrumPoints per call is pure overhead: both are fixed for a whole image.
+func colourIndexAt(x float64, sp int, dbRange float64) int {
 	// NaN dBFS (e.g. from NaN input samples) compares false against every case
 	// below and would fall through to int(NaN), which is implementation-defined
 	// in Go. Map it to the floor colour instead.
 	if math.IsNaN(x) {
 		return fixedPalette
 	}
-	sp := spectrumPoints(o)
-	dbr := float64(o.DBRange)
 	var c int
 	switch {
-	case x < -dbr:
+	case x < -dbRange:
 		c = 0
 	case x >= 0:
 		c = sp - 1
 	default:
-		c = int(1 + (1+x/dbr)*float64(sp-2))
+		c = int(1 + (1+x/dbRange)*float64(sp-2))
 	}
 	return fixedPalette + c
 }

--- a/sox/parity_test.go
+++ b/sox/parity_test.go
@@ -37,7 +37,11 @@ func decodePalettedIndices(t *testing.T, path string) (int, int, []byte) {
 	return w, h, idx
 }
 
-func comparePNGs(t *testing.T, name string, samples []float32, rate int, opt Options, soxArgs []string) {
+// comparePNGs renders with both this package and the sox binary and compares
+// every palette index. maxDelta is the largest per-pixel index difference the
+// case tolerates; it is 0 (bit-exact) for everything except the documented
+// exception in TestRasterParity.
+func comparePNGsTol(t *testing.T, name string, samples []float32, rate int, opt Options, soxArgs []string, maxDelta int) {
 	t.Helper()
 	refPath := soxRunSpectrogram(t, samples, rate, true, soxArgs)
 	opt.Raw = true // this harness compares against `sox ... spectrogram -r`
@@ -71,11 +75,22 @@ func comparePNGs(t *testing.T, name string, samples []float32, rate int, opt Opt
 	total := gw * gh
 	matchPct := 100 * float64(total-mismatch) / float64(total)
 	t.Logf("%s: %.3f%% exact, worst delta %d (%d/%d mismatched)", name, matchPct, worst, mismatch, total)
-	if matchPct < 99.5 {
-		t.Errorf("%s: only %.3f%% exact (want >=99.5%%)", name, matchPct)
+	// The renderer is bit-exact against the binary, so assert exactly that.
+	// A looser bound would let the README's "100.000% of palette indices"
+	// claim rot silently: the float32 FFT this replaced sat at 99.910%, which
+	// the old >=99.5% threshold accepted without complaint.
+	if maxDelta == 0 && mismatch != 0 {
+		t.Errorf("%s: %.3f%% exact, %d/%d pixels differ, worst delta %d (want bit-exact)",
+			name, matchPct, mismatch, total, worst)
 	}
-	if worst > 1 {
-		t.Errorf("%s: worst palette-index delta %d (want <=1)", name, worst)
+	if worst > maxDelta {
+		t.Errorf("%s: worst palette-index delta %d (want <=%d)", name, worst, maxDelta)
+	}
+	// A delta allowance on its own would accept every pixel drifting by one, so
+	// the tolerated cases also have to hold their match rate. The documented
+	// exception sits at 99.920%.
+	if maxDelta > 0 && matchPct < 99.5 {
+		t.Errorf("%s: only %.3f%% exact (want >=99.5%% even with a delta allowance)", name, matchPct)
 	}
 }
 
@@ -111,28 +126,50 @@ func soxSpectrogramSupportsNormalize() bool {
 	return bytes.Contains(out, []byte("\t-n\t"))
 }
 
+func comparePNGs(t *testing.T, name string, samples []float32, rate int, opt Options, soxArgs []string) {
+	t.Helper()
+	comparePNGsTol(t, name, samples, rate, opt, soxArgs, 0)
+}
+
 func TestRasterParity(t *testing.T) {
 	requireSox(t)
 	const rate = 16000
 	cases := []struct {
-		name    string
-		samples []float32
-		opt     Options
-		args    []string
+		name     string
+		samples  []float32
+		opt      Options
+		args     []string
+		maxDelta int // 0 = bit-exact; see zrange-max for the one exception
 	}{
-		{"default-sweep", sweep(rate, 2.0, 200, 6000), Options{}, nil},
-		{"normalize", sweep(rate, 2.0, 200, 6000), Options{Normalize: true}, []string{"-n"}},
-		{"xtrunc", sweep(rate, 3.0, 200, 6000), Options{XSize: 120}, []string{"-x", "120"}},
-		{"ysize512", noise(rate, 1.5, 1), Options{YSize: 257}, []string{"-y", "257"}},
-		{"zrange90", sweep(rate, 2.0, 200, 6000), Options{DBRange: 90}, []string{"-z", "90"}},
-		{"gain20", sweep(rate, 2.0, 200, 6000), Options{Gain: 20}, []string{"-Z", "20"}},
-		{"mono-pal", sweep(rate, 2.0, 200, 6000), Options{Monochrome: true}, []string{"-m"}},
-		{"highcolour", sweep(rate, 2.0, 200, 6000), Options{HighColour: true}, []string{"-h"}},
+		{"default-sweep", sweep(rate, 2.0, 200, 6000), Options{}, nil, 0},
+		{"normalize", sweep(rate, 2.0, 200, 6000), Options{Normalize: true}, []string{"-n"}, 0},
+		{"xtrunc", sweep(rate, 3.0, 200, 6000), Options{XSize: 120}, []string{"-x", "120"}, 0},
+		{"ysize512", noise(rate, 1.5, 1), Options{YSize: 257}, []string{"-y", "257"}, 0},
+		{"zrange90", sweep(rate, 2.0, 200, 6000), Options{DBRange: 90}, []string{"-z", "90"}, 0},
+		{"gain20", sweep(rate, 2.0, 200, 6000), Options{Gain: 20}, []string{"-Z", "20"}, 0},
+		{"mono-pal", sweep(rate, 2.0, 200, 6000), Options{Monochrome: true}, []string{"-m"}, 0},
+		{"highcolour", sweep(rate, 2.0, 200, 6000), Options{HighColour: true}, []string{"-h"}, 0},
 		// SlackOverlap is the only geometry-affecting field; exercise it end-to-end.
-		{"slack", sweep(rate, 2.0, 200, 6000), Options{SlackOverlap: true}, []string{"-s"}},
+		{"slack", sweep(rate, 2.0, 200, 6000), Options{SlackOverlap: true}, []string{"-s"}, 0},
 		// Two lengths to exercise both branches of the drain remainder logic.
-		{"drain-a", noise(rate, 1.37, 7), Options{}, nil},
-		{"drain-b", noise(rate, 1.61, 9), Options{}, nil},
+		{"drain-a", noise(rate, 1.37, 7), Options{}, nil, 0},
+		{"drain-b", noise(rate, 1.61, 9), Options{}, nil, 0},
+		// The dynamic-range extremes validate() permits. The upper end matters
+		// most: at -z 180 a bin 150 dB down is still a distinguishable colour,
+		// so it is the case where a transform that flushed low-energy bins
+		// would actually show.
+		{"zrange-min", sweep(rate, 2.0, 200, 6000), Options{DBRange: 20}, []string{"-z", "20"}, 0},
+		// PRE-EXISTING, not caused by this package's transform: at the maximum
+		// dynamic range validate() allows, 329/410400 pixels land one palette
+		// index off SoX. The count is byte-identical on the float32 FFT this
+		// replaced, so the cause is palette quantisation at the extreme range,
+		// not the DFT. Tracked separately; asserted at delta <= 1 so a real
+		// regression here still fails.
+		{"zrange-max", sweep(rate, 2.0, 200, 6000), Options{DBRange: 180}, []string{"-z", "180"}, 1},
+		// A width that is not a multiple of the raster transpose's 64-wide
+		// tile, so the ragged edge is checked pixel-exact against the oracle
+		// rather than merely for absence of a panic.
+		{"xsize-ragged", sweep(rate, 2.0, 200, 6000), Options{XSize: 517}, []string{"-x", "517"}, 0},
 	}
 	normalizeSupported := soxSpectrogramSupportsNormalize()
 	for _, c := range cases {
@@ -141,7 +178,7 @@ func TestRasterParity(t *testing.T) {
 			if c.name == "normalize" && !normalizeSupported {
 				t.Skip("installed sox does not support spectrogram -n (normalize); added in 14.4.3+")
 			}
-			comparePNGs(t, c.name, c.samples, rate, c.opt, c.args)
+			comparePNGsTol(t, c.name, c.samples, rate, c.opt, c.args, c.maxDelta)
 		})
 	}
 }
@@ -197,18 +234,19 @@ func compareFullPNGs(t *testing.T, name string, samples []float32, rate int, opt
 			}
 		}
 	}
-	if chromeBad > 5 {
-		t.Errorf("%s: %d chrome pixels differ in total", name, chromeBad)
+	// Chrome is drawn from the same font and tick math as SoX, so it matches
+	// exactly; asserting that keeps the README's "chrome and raster alike"
+	// claim honest.
+	if chromeBad != 0 {
+		t.Errorf("%s: %d chrome pixels differ (want 0)", name, chromeBad)
 	}
 	total := rasterCols * rasterRows
 	matchPct := 100 * float64(total-mismatch) / float64(total)
 	t.Logf("%s: raster %.3f%% exact, worst delta %d; chrome mismatches %d",
 		name, matchPct, worst, chromeBad)
-	if matchPct < 99.5 {
-		t.Errorf("%s: raster only %.3f%% exact (want >=99.5%%)", name, matchPct)
-	}
-	if worst > 1 {
-		t.Errorf("%s: worst raster delta %d (want <=1)", name, worst)
+	if mismatch != 0 {
+		t.Errorf("%s: raster %.3f%% exact, %d/%d pixels differ, worst delta %d (want bit-exact)",
+			name, matchPct, mismatch, total, worst)
 	}
 }
 

--- a/sox/render_bench_test.go
+++ b/sox/render_bench_test.go
@@ -2,6 +2,7 @@ package sox
 
 import (
 	"math"
+	"path/filepath"
 	"testing"
 )
 
@@ -89,6 +90,30 @@ func BenchmarkAnalyzer(b *testing.B) {
 					b.Fatal(err)
 				}
 				a.run(sig)
+			}
+		})
+	}
+}
+
+// BenchmarkWritePNG is the apples-to-apples comparison against the SoX binary:
+// Render alone produces an in-memory image, whereas invoking `sox` also pays
+// for deflate-encoding the PNG and writing it out.
+func BenchmarkWritePNG(b *testing.B) {
+	sig := benchSignal(benchSeconds*benchRate, benchRate)
+	dir := b.TempDir()
+	for _, p := range benchPresets {
+		b.Run(p.name, func(b *testing.B) {
+			opt := Options{XSize: p.xSize, YSize: p.ySize}
+			out := filepath.Join(dir, p.name+".png")
+			if err := WritePNG(out, sig, benchRate, opt); err != nil {
+				b.Fatalf("write: %v", err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if err := WritePNG(out, sig, benchRate, opt); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}

--- a/sox/render_bench_test.go
+++ b/sox/render_bench_test.go
@@ -38,9 +38,10 @@ func benchSignal(n int, rate float64) []float32 {
 }
 
 // BenchmarkRender covers the full in-process render at birdnet-go's settings,
-// with and without chrome. The reference to beat is the SoX 14.4.2 binary,
-// which on an i7-1260P takes roughly 5/8/14/55 ms for these four presets
-// (including process spawn).
+// with and without chrome. Note that Render stops at an in-memory image, so the
+// like-for-like comparison against the sox binary is BenchmarkWritePNG below,
+// not this one. See the README for the measured figures; do not restate them
+// here, so the two cannot drift apart.
 func BenchmarkRender(b *testing.B) {
 	sig := benchSignal(benchSeconds*benchRate, benchRate)
 	for _, p := range benchPresets {
@@ -82,6 +83,12 @@ func BenchmarkAnalyzer(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
+				// a.run mutates ws.window through makeWindow, so the window
+				// state cannot be shared across iterations. Build it with the
+				// timer stopped: newAnalyzer also builds an fft.Plan, whose
+				// twiddle tables cost ~2*half Sincos calls, and timing that
+				// would measure plan construction rather than the DSP.
+				b.StopTimer()
 				ws := newWindowState(dft, o.Window)
 				actual := makeWindow(ws, 0)
 				step, blocks, norm := stepSizing(actual, dft, benchRate, pps, o.SlackOverlap)
@@ -89,15 +96,21 @@ func BenchmarkAnalyzer(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
+				b.StartTimer()
+
 				a.run(sig)
 			}
 		})
 	}
 }
 
-// BenchmarkWritePNG is the apples-to-apples comparison against the SoX binary:
-// Render alone produces an in-memory image, whereas invoking `sox` also pays
-// for deflate-encoding the PNG and writing it out.
+// BenchmarkWritePNG is the closest comparison against the SoX binary: Render
+// alone produces an in-memory image, whereas invoking `sox` also pays for
+// deflate-encoding the PNG and writing it out.
+//
+// It is still not exact: b.TempDir() is usually tmpfs, and WritePNG does not
+// fsync, so the write half is a memcpy into the page cache plus a rename rather
+// than real device I/O. Treat it as a CPU comparison.
 func BenchmarkWritePNG(b *testing.B) {
 	sig := benchSignal(benchSeconds*benchRate, benchRate)
 	dir := b.TempDir()

--- a/sox/render_bench_test.go
+++ b/sox/render_bench_test.go
@@ -1,0 +1,95 @@
+package sox
+
+import (
+	"math"
+	"testing"
+)
+
+// The four presets birdnet-go renders (see its validSizes map): width in pixels
+// with YSize = 2^n+1, so dft = 2*(YSize-1) is a power of two.
+var benchPresets = []struct {
+	name  string
+	xSize int
+	ySize int
+}{
+	{"sm_258x129_dft256", 258, 129},
+	{"md_514x257_dft512", 514, 257},
+	{"lg_1026x513_dft1024", 1026, 513},
+	{"xl_2050x1025_dft2048", 2050, 1025},
+}
+
+// benchClip is a 15 s mono clip at 24 kHz, matching birdnet-go's bird profile
+// (clips are resampled with `rate 24000` before the spectrogram effect).
+const (
+	benchSeconds = 15
+	benchRate    = 24000
+)
+
+func benchSignal(n int, rate float64) []float32 {
+	s := make([]float32, n)
+	for i := range s {
+		t := float64(i) / rate
+		s[i] = float32(0.4*math.Sin(2*math.Pi*1000*t) +
+			0.2*math.Sin(2*math.Pi*3500*t) +
+			0.1*math.Sin(2*math.Pi*7000*t))
+	}
+	return s
+}
+
+// BenchmarkRender covers the full in-process render at birdnet-go's settings,
+// with and without chrome. The reference to beat is the SoX 14.4.2 binary,
+// which on an i7-1260P takes roughly 5/8/14/55 ms for these four presets
+// (including process spawn).
+func BenchmarkRender(b *testing.B) {
+	sig := benchSignal(benchSeconds*benchRate, benchRate)
+	for _, p := range benchPresets {
+		for _, raw := range []bool{false, true} {
+			name := p.name
+			if raw {
+				name += "_raw"
+			}
+			b.Run(name, func(b *testing.B) {
+				opt := Options{XSize: p.xSize, YSize: p.ySize, Raw: raw}
+				if _, err := Render(sig, benchRate, opt); err != nil {
+					b.Fatalf("render: %v", err)
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					if _, err := Render(sig, benchRate, opt); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkAnalyzer isolates the DSP half (window + DFT + dB conversion) from
+// the rasterization half, so a change to one is not masked by the other.
+func BenchmarkAnalyzer(b *testing.B) {
+	sig := benchSignal(benchSeconds*benchRate, benchRate)
+	for _, p := range benchPresets {
+		b.Run(p.name, func(b *testing.B) {
+			o := normalize(Options{XSize: p.xSize, YSize: p.ySize})
+			if err := validate(o); err != nil {
+				b.Fatal(err)
+			}
+			dft, rows := deriveDFTSize(o)
+			duration := float64(len(sig)) / benchRate
+			xSize, pps := resolveTimeAxis(o, duration)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				ws := newWindowState(dft, o.Window)
+				actual := makeWindow(ws, 0)
+				step, blocks, norm := stepSizing(actual, dft, benchRate, pps, o.SlackOverlap)
+				a, err := newAnalyzer(dft, rows, step, blocks, norm, -o.Gain, o.DBRange, ws, xSize)
+				if err != nil {
+					b.Fatal(err)
+				}
+				a.run(sig)
+			}
+		})
+	}
+}

--- a/sox/sox.go
+++ b/sox/sox.go
@@ -53,11 +53,22 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 	// Resolve the palette constants once: they are fixed for the whole raster,
 	// and this loop runs once per pixel.
 	sp, dbRange := spectrumPoints(o), float64(o.DBRange)
-	for col := 0; col < cols; col++ {
-		src := a.dBfs[col*rows : (col+1)*rows]
-		for row, d := range src {
-			v := float64(d) + autogain
-			cv.pix[(rasterY+row)*colsTotal+rasterX+col] = uint8(colourIndexAt(v, sp, dbRange))
+	// dBfs is column-major but the canvas is row-major, so this is a transpose.
+	// Walking it naively streams one source column against a destination stride
+	// of colsTotal, which evicts the destination from cache once per column at
+	// larger sizes. Tiling keeps both sides of the transpose resident.
+	const tile = 64
+	for colBase := 0; colBase < cols; colBase += tile {
+		colEnd := min(colBase+tile, cols)
+		for rowBase := 0; rowBase < rows; rowBase += tile {
+			rowEnd := min(rowBase+tile, rows)
+			for col := colBase; col < colEnd; col++ {
+				src := a.dBfs[col*rows : (col+1)*rows]
+				for row := rowBase; row < rowEnd; row++ {
+					v := float64(src[row]) + autogain
+					cv.pix[(rasterY+row)*colsTotal+rasterX+col] = uint8(colourIndexAt(v, sp, dbRange))
+				}
+			}
 		}
 	}
 	if !o.Raw {

--- a/sox/sox.go
+++ b/sox/sox.go
@@ -5,6 +5,7 @@ import (
 	"image"
 	"image/png"
 	"os"
+	"path/filepath"
 )
 
 // Render computes the SoX-compatible spectrogram image for mono `samples` at
@@ -32,7 +33,7 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 
 	a, err := newAnalyzer(dft, rows, step, blocks, norm, -o.Gain, o.DBRange, ws, xSize)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("sox: building the analyzer for DFT size %d: %w", dft, err)
 	}
 	cols := a.run(samples)
 
@@ -65,8 +66,10 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 			// row-then-col inside the tile so the destination is written
 			// sequentially; the strided source reads stay in L1 for a 64x64 tile.
 			for row := rowBase; row < rowEnd; row++ {
-				// Slice to exactly the tile's span so the write is bounds-check
-				// free; ranging over it is what proves dst[i] in range.
+				// Slice to exactly the tile's span so the WRITE is bounds-check
+				// free; ranging over it is what proves dst[i] in range. The
+				// strided source read still carries one check per pixel, which
+				// Go has no way to express away.
 				start := (rasterY+row)*colsTotal + rasterX + colBase
 				dst := cv.pix[start : start+colEnd-colBase]
 				for i := range dst {
@@ -99,19 +102,56 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 }
 
 // WritePNG renders and encodes to path with the stdlib PNG encoder.
-func WritePNG(path string, samples []float32, sampleRate float64, opt Options) error {
+//
+// The image is written to a unique temporary file in the destination directory
+// and renamed into place, so path either does not exist yet or holds a complete
+// PNG. Encoding a large spectrogram takes milliseconds and consumers commonly
+// serve these files while they are being produced; writing in place would let a
+// reader observe a truncated image.
+//
+// The rename is what provides atomicity. There is deliberately no fsync: it
+// would cost more than the encode on slow storage, and it buys durability
+// across a power cut rather than atomicity, which is not a guarantee the sox
+// binary offers either.
+func WritePNG(path string, samples []float32, sampleRate float64, opt Options) (err error) {
 	img, err := Render(samples, sampleRate, opt)
 	if err != nil {
 		return err
 	}
-	f, err := os.Create(path)
+
+	// Same directory as the destination, so the rename cannot cross a
+	// filesystem boundary. A unique name keeps concurrent writers of the same
+	// destination from sharing a temporary.
+	f, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp*")
 	if err != nil {
 		return err
 	}
-	if err := png.Encode(f, img); err != nil {
-		f.Close()
-		os.Remove(path) // don't leave a partial/corrupt file behind
+	tmp := f.Name()
+	renamed := false
+	defer func() {
+		// Keyed on renamed, not on err: a panic in the encoder would leave err
+		// nil and strand the temporary file otherwise.
+		if !renamed {
+			f.Close()
+			os.Remove(tmp)
+		}
+	}()
+
+	if err = png.Encode(f, img); err != nil {
 		return err
 	}
-	return f.Close()
+	if err = f.Close(); err != nil {
+		return err
+	}
+	// os.CreateTemp creates with 0600, but callers expect the 0666&^umask that
+	// os.Create used to give them. A spectrogram served by another user or
+	// container is a normal deployment, and 0600 silently breaks it.
+	if err = os.Chmod(tmp, 0o644); err != nil {
+		return err
+	}
+	if err = os.Rename(tmp, path); err != nil {
+		return err
+	}
+	renamed = true
+	return nil
 }

--- a/sox/sox.go
+++ b/sox/sox.go
@@ -62,11 +62,13 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 		colEnd := min(colBase+tile, cols)
 		for rowBase := 0; rowBase < rows; rowBase += tile {
 			rowEnd := min(rowBase+tile, rows)
-			for col := colBase; col < colEnd; col++ {
-				src := a.dBfs[col*rows : (col+1)*rows]
-				for row := rowBase; row < rowEnd; row++ {
-					v := float64(src[row]) + autogain
-					cv.pix[(rasterY+row)*colsTotal+rasterX+col] = uint8(colourIndexAt(v, sp, dbRange))
+			// row-then-col inside the tile so the destination is written
+			// sequentially; the strided source reads stay in L1 for a 64x64 tile.
+			for row := rowBase; row < rowEnd; row++ {
+				dst := cv.pix[(rasterY+row)*colsTotal+rasterX:]
+				for col := colBase; col < colEnd; col++ {
+					v := float64(a.dBfs[col*rows+row]) + autogain
+					dst[col] = uint8(colourIndexAt(v, sp, dbRange))
 				}
 			}
 		}

--- a/sox/sox.go
+++ b/sox/sox.go
@@ -50,10 +50,14 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 
 	// Draw in SoX's bottom-up coordinates, then blit flipped.
 	cv := &canvas{pix: make([]uint8, colsTotal*rowsTotal), cols: colsTotal}
+	// Resolve the palette constants once: they are fixed for the whole raster,
+	// and this loop runs once per pixel.
+	sp, dbRange := spectrumPoints(o), float64(o.DBRange)
 	for col := 0; col < cols; col++ {
-		for row := 0; row < rows; row++ {
-			v := float64(a.dBfs[col*rows+row]) + autogain
-			cv.set(rasterX+col, rasterY+row, uint8(colourIndex(o, v)))
+		src := a.dBfs[col*rows : (col+1)*rows]
+		for row, d := range src {
+			v := float64(d) + autogain
+			cv.pix[(rasterY+row)*colsTotal+rasterX+col] = uint8(colourIndexAt(v, sp, dbRange))
 		}
 	}
 	if !o.Raw {

--- a/sox/sox.go
+++ b/sox/sox.go
@@ -30,7 +30,10 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 	actual := makeWindow(ws, 0)
 	step, blocks, norm := stepSizing(actual, dft, sampleRate, pps, o.SlackOverlap)
 
-	a := newAnalyzer(dft, rows, step, blocks, norm, -o.Gain, o.DBRange, ws, xSize)
+	a, err := newAnalyzer(dft, rows, step, blocks, norm, -o.Gain, o.DBRange, ws, xSize)
+	if err != nil {
+		return nil, err
+	}
 	cols := a.run(samples)
 
 	autogain := 0.0

--- a/sox/sox.go
+++ b/sox/sox.go
@@ -65,10 +65,13 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 			// row-then-col inside the tile so the destination is written
 			// sequentially; the strided source reads stay in L1 for a 64x64 tile.
 			for row := rowBase; row < rowEnd; row++ {
-				dst := cv.pix[(rasterY+row)*colsTotal+rasterX:]
-				for col := colBase; col < colEnd; col++ {
-					v := float64(a.dBfs[col*rows+row]) + autogain
-					dst[col] = uint8(colourIndexAt(v, sp, dbRange))
+				// Slice to exactly the tile's span so the write is bounds-check
+				// free; ranging over it is what proves dst[i] in range.
+				start := (rasterY+row)*colsTotal + rasterX + colBase
+				dst := cv.pix[start : start+colEnd-colBase]
+				for i := range dst {
+					v := float64(a.dBfs[(colBase+i)*rows+row]) + autogain
+					dst[i] = uint8(colourIndexAt(v, sp, dbRange))
 				}
 			}
 		}

--- a/sox/sox.go
+++ b/sox/sox.go
@@ -113,6 +113,14 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 // would cost more than the encode on slow storage, and it buys durability
 // across a power cut rather than atomicity, which is not a guarantee the sox
 // binary offers either.
+//
+// Windows note: os.Rename replaces an existing destination (Go passes
+// MOVEFILE_REPLACE_EXISTING), so repeated writes to the same path work. It can
+// however fail with a sharing violation if another process holds the
+// destination open without FILE_SHARE_DELETE, where the previous truncate in
+// place would have succeeded. That trade is deliberate: a reader that had the
+// old file open keeps reading a complete image rather than watching one be
+// overwritten underneath it.
 func WritePNG(path string, samples []float32, sampleRate float64, opt Options) (err error) {
 	img, err := Render(samples, sampleRate, opt)
 	if err != nil {
@@ -145,9 +153,11 @@ func WritePNG(path string, samples []float32, sampleRate float64, opt Options) (
 	if err = f.Close(); err != nil {
 		return err
 	}
-	// os.CreateTemp creates with 0600, but callers expect the 0666&^umask that
-	// os.Create used to give them. A spectrogram served by another user or
-	// container is a normal deployment, and 0600 silently breaks it.
+	// os.CreateTemp creates with 0600, which would silently break the common
+	// deployment where another user or container serves the file. os.Create
+	// gave 0666&^umask; this does not reproduce that exactly, it guarantees
+	// group and world readability and owner write, which is what consumers
+	// actually depend on.
 	if err = os.Chmod(tmp, 0o644); err != nil {
 		return err
 	}

--- a/sox/sox.go
+++ b/sox/sox.go
@@ -132,8 +132,10 @@ func WritePNG(path string, samples []float32, sampleRate float64, opt Options) (
 		// Keyed on renamed, not on err: a panic in the encoder would leave err
 		// nil and strand the temporary file otherwise.
 		if !renamed {
-			f.Close()
-			os.Remove(tmp)
+			// Best-effort cleanup on the failure path; the caller already has
+			// the error that got us here, so these add nothing.
+			_ = f.Close()
+			_ = os.Remove(tmp)
 		}
 	}()
 


### PR DESCRIPTION
## Summary

Makes the `sox` renderer fast enough to replace the external `sox` binary in-process, and tightens its output from "within one palette index" to bit-exact.

The transform dominated the render (67% on amd64, 61% on arm64) and neither existing implementation was fast enough: `internal/dsp` ran a full-size complex FFT over real input, and simd's `f64.STFTPlan` halves that but leaves the butterfly scalar. `internal/fft` is a vendored radix-4 real-input transform: one pass does the work of two radix-2 stages with three quarters of the complex multiplies, the digit reversal is folded into the windowed load, the leading radix-2 stage runs where every twiddle is 1, and bins `k` and `half-k` are emitted together from one set of loads. It is deliberately minimal (one frame, no framing or padding modes) so it can collapse back into a simd call once tphakala/simd#192 lands vectorized f64 kernels.

Alongside that: a 64x64 tiled column-major-to-row-major raster transpose, palette constants hoisted out of the per-pixel loop (`colourIndex` was copying a 152-byte `Options` struct 526k times per image), the dB conversion vectorized onto simd, bulk sample loads, and bounds-check elimination in the three hot kernels.

### Results

Rendering a 15 s mono clip at 24 kHz. Compare `WritePNG` against the binary, since `Render` stops at an in-memory image while `sox` also encodes and writes a PNG.

amd64 (i7-1260P), best of 12, pinned to P-cores:

| size | dft | `Render` | `WritePNG` | SoX 14.4.2 |
|---|---|---|---|---|
| 258 x 129 | 256 | 2.7 ms | **4.0 ms** | 5 ms |
| 514 x 257 | 512 | 3.9 ms | **5.7 ms** | 6 ms |
| 1026 x 513 | 1024 | 6.8 ms | **9.3 ms** | 13 ms |
| 2050 x 1025 | 2048 | 28.0 ms | **34.8 ms** | 51 ms |

arm64 (Raspberry Pi 5), where the binary previously won at every size by 1.2-1.5x:

| size | `WritePNG` | SoX 14.4.2 |
|---|---|---|
| 258 x 129 | 9.5 ms | **9 ms** |
| 514 x 257 | 14.3 ms | **14 ms** |
| 1026 x 513 | **28.3 ms** | 30 ms |
| 2050 x 1025 | **109.6 ms** | 112 ms |

### Exactness

Moving the transform to float64 matches SoX's own double-precision `lsx_rdft` and closes the last numerical gap: raster parity against the binary goes from 99.910% exact (worst delta 1) to bit-exact. The parity tests now assert that literally (`mismatch != 0`) rather than the previous `>= 99.5%`, which would have accepted a regression back to the old behaviour, and the same assertion covers chrome.

One documented exception: at `DBRange` 180, the maximum `validate` accepts, 329 of 410400 pixels land one index off. That is pre-existing and not from this transform, the count is byte-identical on `main` and identical again on arm64, so it is palette quantisation at the extreme of the range. It is asserted at delta <= 1 with a match-rate floor so a real regression there still fails.

CI previously ran one architecture and one simd dispatch path while the exactness claim covered three. It now runs amd64 and arm64, plus a parity pass with `SIMD_DISABLE=all` for the scalar fallback kernel.

### Notable behavioural change for consumers

Rendered pixels differ from `main` by 0.001-0.003% of pixels, max one palette index, because the pipeline is now float64 end to end. This is a move toward the reference, not away from it, but any downstream golden-image fixture will need regenerating.

`WritePNG` now writes to a temporary file in the destination directory and renames it into place, so the destination never holds a truncated PNG. It keeps mode 0644 (`os.CreateTemp` would otherwise publish 0600) and deliberately does not fsync, since the rename is what provides atomicity.

## Related Issues

None on this repo. Upstream follow-up: tphakala/simd#192 tracks the vectorized f64 butterfly that would make `internal/fft` unnecessary.

## Test Plan

- [x] `go test -race ./...` green on amd64 and arm64
- [x] Parity against the installed SoX 14.4.2 binary: bit-exact on 24 of 25 assertions, with the `DBRange` 180 case pinned at delta <= 1
- [x] Parity green with `SIMD_DISABLE=all` (scalar Log10 fallback) on both architectures
- [x] Transform verified bit-identical before/after the bounds-check work across every size from 4 to 4096
- [x] `FuzzPowerInto` survives 4.1M executions
- [x] Mutation-tested: sign flip in the radix-4 butterfly, skipped middle bin, twiddle off-by-one, broken radix-2 stage, dropped window, DC/Nyquist swap, low-bin flush, vertically mirrored raster, and halved palette are all caught

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster spectrogram analysis and rendering across supported platforms, including ARM64.
  * Added safer PNG generation with atomic file publishing and cleanup after failures.
  * Improved handling of edge cases, including silence, unusual dimensions, and non-finite input values.

* **Bug Fixes**
  * Improved rendering consistency and bit-exact parity with reference output.
  * Corrected validation and error reporting for unsupported spectrogram configurations.

* **Documentation**
  * Updated performance results, platform notes, package descriptions, and setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->