### PR TITLE
perf(sox): parallel rendering, simd butterfly, and a leaner analysis pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ go.work.sum
 # Tooling state and local planning docs (never commit)
 .serena/
 docs/superpowers/
+.codegraph/

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ written to answer "can the spectrogram run in realtime in Go" with a hard
 in-language number and to scope what `simd` needs. It now supports multiple
 spectrogram types: the original mel-tensor generator (`mel`) and a
 SoX-compatible image renderer (`sox`). The two no longer share a transform:
-`sox` runs the vendored real-input radix-4 FFT in `internal/fft`, `mel` is
+`sox` runs the vendored real-input mixed-radix FFT in `internal/fft`, `mel` is
 still on the full-size complex FFT in `internal/dsp`.
 
-## Current results (i7-1260P, AVX2+FMA)
+## Current results
 
 ### `sox`: faster than the SoX binary, and bit-exact against it
 
@@ -23,45 +23,54 @@ returns an in-memory `*image.Paletted`, whereas the binary also deflate-encodes
 the PNG and writes it out, which is several ms on its own. The SoX timing
 includes process spawn, since that is part of what invoking it costs.
 
-amd64 (i7-1260P), best of 12, pinned to P-cores:
+`Render` uses every core by default (see `Options.Workers`); the `1 core`
+column is the same call with `Workers: 1`, so the two together separate what
+the per-core work costs from what parallelism buys.
 
-| size        | dft  | `Render` | `WritePNG` | SoX 14.4.2 |
-|-------------|------|----------|------------|------------|
-| 258 x 129   | 256  | 2.7 ms   | **4.0 ms** | 5 ms       |
-| 514 x 257   | 512  | 3.9 ms   | **5.7 ms** | 6 ms       |
-| 1026 x 513  | 1024 | 6.8 ms   | **9.3 ms** | 13 ms      |
-| 2050 x 1025 | 2048 | 28.0 ms  | **34.8 ms**| 51 ms      |
+amd64 (i7-1260P, AVX2+FMA), idle host, `performance` governor, 4 P-cores,
+best of 6:
 
-`WritePNG` uses the stdlib encoder at its default compression, which is about
-2.5 ms of the 9.3 ms at 1026 x 513. A caller that would rather trade file size
-for latency can use `Render` and encode itself: `png.BestSpeed` cuts that to
-1.5 ms at the cost of roughly 9 KiB -> 14 KiB per image.
+| size        | dft  | `Render` | `Render` 1 core | `WritePNG` | SoX 14.4.2 |
+|-------------|------|----------|-----------------|------------|------------|
+| 258 x 129   | 256  | 0.8 ms   | 2.1 ms          | **1.9 ms** | 5.4 ms     |
+| 514 x 257   | 512  | 1.0 ms   | 2.4 ms          | **2.6 ms** | 7.0 ms     |
+| 1026 x 513  | 1024 | 1.7 ms   | 4.5 ms          | **4.4 ms** | 12.9 ms    |
+| 2050 x 1025 | 2048 | 5.6 ms   | 15.7 ms         | **12.3 ms**| 45.2 ms    |
 
-### arm64
+arm64 (Raspberry Pi 5, Cortex-A76 at a pinned 2.4 GHz, Debian 13, Go 1.26.1),
+the deployment target that matters most here, measured the same way:
 
-The same comparison on a Raspberry Pi 5 (Cortex-A76, Debian 13, Go 1.26.1),
-the deployment target that matters most here:
+| size        | `Render` | `Render` 1 core | `WritePNG` | SoX 14.4.2 |
+|-------------|----------|-----------------|------------|------------|
+| 258 x 129   | 2.1 ms   | 6.9 ms          | **4.1 ms** | 10.3 ms    |
+| 514 x 257   | 2.6 ms   | 8.4 ms          | **6.1 ms** | 14.6 ms    |
+| 1026 x 513  | 5.3 ms   | 16.9 ms         | **11.5 ms**| 30.6 ms    |
+| 2050 x 1025 | 18.7 ms  | 63.7 ms         | **36.1 ms**| 112.6 ms   |
 
-| size        | `WritePNG` | SoX 14.4.2 |
-|-------------|------------|------------|
-| 258 x 129   | 9.5 ms     | **9 ms**   |
-| 514 x 257   | 14.3 ms    | **14 ms**  |
-| 1026 x 513  | **28.3 ms**| 30 ms      |
-| 2050 x 1025 | **109.6 ms**| 112 ms    |
+So `WritePNG` is 2.7-3.7x the SoX binary on amd64 and 2.4-3.1x on arm64. arm64
+used to be the harder target, at a wash or worse; it no longer is, because the
+same three things pay off on both: the vectorized butterfly has a NEON path,
+the columns parallelise the same way, and the passes that were removed were
+removed everywhere.
 
-Parity holds identically here, including the `DBRange` 180 exception above,
-which produces the same 329 mismatches on both architectures. CI now proves that
-rather than taking it on trust: the test job runs on both `ubuntu-latest` and
-`ubuntu-24.04-arm`, so the NEON `Log10` kernel is held to exactly the same
-assertions as the AVX2 one. A further step re-runs the parity comparison with
-`SIMD_DISABLE=all`, since simd picks a vectorized or scalar kernel per host and
-the two do not agree to the last ulp.
+At the largest size `WritePNG` is now more than half PNG encoding: 12.3 ms
+against 5.6 ms for `Render`. That is the stdlib encoder at its default
+compression. A caller that would rather trade file size for latency can use
+`Render` and encode itself with `png.BestSpeed`.
 
-arm64 is the harder target. Before the transform was vendored, SoX won by
-1.2-1.5x at every size here; it is now a wash at the small sizes and a small
-win at the large ones. `internal/fft` is the reason, and further gains need
-simd [#192](https://github.com/tphakala/simd/issues/192) to vectorize the
-butterfly.
+None of this cost any parity. Against the `sox` binary on the same host, every
+case is 100.000% of pixels exact with worst delta 0, chrome and raster alike,
+on both architectures, with the AVX2 kernels on amd64 and the NEON ones on
+arm64. The one exception is unchanged and pre-dates all of this: at `DBRange`
+180, 329 of 410400 pixels land one palette index off, identically on both
+architectures. CI proves the rest rather than taking it on trust: the test job
+runs on both `ubuntu-latest` and `ubuntu-24.04-arm`, and a further step re-runs
+the comparison with `SIMD_DISABLE=all`, since simd picks a vectorized or scalar
+kernel per host and the two do not agree to the last ulp.
+
+That the vectorized butterfly changes nothing here is worth stating plainly: it
+associates the arithmetic differently from the scalar radix-4 loop it replaced,
+so it is not bit-identical to it, and the images still are.
 
 Choosing float32 over float64 would not help here: measured on the Pi, simd's
 f32 and f64 STFT plans came within 0.4% of each other at every transform size,
@@ -71,13 +80,36 @@ SoX's own double-precision `lsx_rdft`, so it is the right default. (This
 package has no float32 variant to select; the comparison was between simd's
 two plans.)
 
+### Where the time goes now
+
+Profiling one 2050 x 1025 render on a single core, after the work above:
+
+| | share |
+|---|---|
+| `unravelPower` (real-FFT recombination, scalar) | 15% |
+| butterflies (`f64.ButterflyComplex` + scalar radix-4) | 26% |
+| frame load, window and digit reversal | 11% |
+| palette quantisation | 10% |
+| `f64.Log10` | 10% |
+| raster transpose | 6% |
+
+The transform is still over half the work. The two things that would move it
+next both need simd kernels rather than anything in this repo, and are filed as
+simd [#198](https://github.com/tphakala/simd/issues/198): a stage-level
+butterfly (the current per-block API costs one call per block, so short spans
+are dominated by call overhead) and a real-FFT unpack that writes `|X_k|^2`
+directly. The latter is why `unravelPower` is still scalar: v1.6.0's
+`RealFFTUnpack` is correct and vectorized and still measured 13% slower here,
+because writing the complex spectrum and squaring it afterwards costs two more
+passes over the bins than emitting power in one.
+
 ### `mel`: realtime bat preprocessing
 
 - **8.9 ms** to compute the mel spectrogram for **1 second** of 384 kHz audio.
 - **~106x realtime**, **0.94%** of one core, **zero allocations** in the hot path.
 - Still on `internal/dsp`'s full-size complex FFT, so it pays roughly twice the
-  transform that `sox` now does. Moving it onto a real-input transform is the
-  obvious next speedup here.
+  transform that `sox` now does, and none of the `sox` work above. Moving it
+  onto `internal/fft` is the obvious next speedup here.
 
 ```
 go test ./...                              # correctness, plus SoX parity when sox is installed
@@ -88,14 +120,16 @@ go test -run XXX -fuzz FuzzPowerInto ./internal/fft/   # transform invariants
 
 The parity tests need the `sox` binary on PATH and skip without it. On a
 hybrid-core host (Intel P/E), pin the benchmarks or the numbers are noise: an
-unpinned run on the i7-1260P above swung by up to 69% between repeats.
+unpinned run on the i7-1260P above swung by up to 69% between repeats. Pin the
+CPU governor too; on a busy laptop the same benchmark varied by more than the
+changes being measured.
 
 ```
 taskset -c 0,2,4,6 env GOMAXPROCS=4 go test -bench=. -run=XXX -count=10 ./sox/
 ```
 
 The module depends on [`github.com/tphakala/simd`](https://github.com/tphakala/simd)
-(pinned to `v1.5.0` in `go.mod`), so a fresh clone builds and tests with the
+(pinned to `v1.6.0` in `go.mod`), so a fresh clone builds and tests with the
 standard `go build ./...` / `go test ./...`, no local checkout or `replace`
 needed. To co-develop against a local `simd` working copy, add a temporary
 `replace github.com/tphakala/simd => ../simd` to `go.mod` (do not commit it).
@@ -116,13 +150,16 @@ types over shared DSP primitives:
   tick labels, dBFS legend, title/comment, SoX's embedded bitmap font) by
   default, bare raster via `Raw: true` (`sox ... -r`). Mono input,
   power-of-2 DFT, all SoX palette modes.
-- `internal/fft/` - vendored radix-4 real-input transform used by `sox`. The
-  transform dominates the render, and neither alternative was fast enough:
-  `internal/dsp` runs a full-size complex FFT over real input, and simd's
-  `f64.STFTPlan` halves that but leaves the butterfly scalar. simd
-  [#192](https://github.com/tphakala/simd/issues/192) tracks the f64 kernels
-  that would make this package unnecessary. Deliberately minimal (one frame, no
-  framing or padding modes) so it can collapse back into a simd call.
+- `internal/fft/` - vendored real-input transform used by `sox`. The transform
+  dominates the render, and neither alternative was fast enough: `internal/dsp`
+  runs a full-size complex FFT over real input, and simd's `f64.STFTPlan`
+  halves that but leaves the butterfly scalar. It runs a scalar radix-4
+  butterfly at the small spans and simd's vectorized `f64.ButterflyComplex`
+  (added for [#192](https://github.com/tphakala/simd/issues/192)) from span 8
+  up, which is where the kernel's per-call overhead stops mattering.
+  Deliberately minimal (one frame, no framing or padding modes) so it can
+  collapse back into a simd call once
+  [#198](https://github.com/tphakala/simd/issues/198) lands.
 - `internal/dsp/` - radix-2 FFT still used by `mel`, plus shared helpers.
 - `cmd/bench` - realtime-factor demo for the mel generator.
 
@@ -143,6 +180,8 @@ img, err = sox.Render(samples, 44100, sox.Options{Title: "My clip"}) // with tit
   128 mels, 9-150 kHz). Generalizing those and adding a plain linear/STFT
   spectrogram is the obvious next step. (`sox` is fully parameterised via
   `Options`; this bullet is about `mel` only.)
+- `mel` has had none of the `sox` optimisation work: no parallelism, no
+  real-input transform, no fused quantisation.
 - Framing is `center=false` (streaming-friendly). librosa's default
   `center=true` adds n_fft/2 padding; matching it bit-for-bit is a follow-up, as
   is a golden-file parity test against a librosa reference.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/tphakala/go-spectrogram
 
 go 1.26
 
-require github.com/tphakala/simd v1.5.0
+require github.com/tphakala/simd v1.6.0
 
 require golang.org/x/sys v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tphakala/simd v1.5.0 h1:COWpfomiIB2H+lWCDysSRCXoQws/CX1lA/S7vRHgrUo=
 github.com/tphakala/simd v1.5.0/go.mod h1:RDX4bQNU8wV5JAYHEkic0l1CcQpBUwV7odEISuOvpUY=
+github.com/tphakala/simd v1.6.0 h1:PvxsMd1O9qRpULHmOcHyTNpaGSo/R8dnAe+Rde3vVPE=
+github.com/tphakala/simd v1.6.0/go.mod h1:RDX4bQNU8wV5JAYHEkic0l1CcQpBUwV7odEISuOvpUY=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/fft/fft.go
+++ b/internal/fft/fft.go
@@ -4,16 +4,20 @@
 // It exists because the transform is the renderer's dominant cost and neither
 // available implementation was fast enough: the internal/dsp plan this package
 // displaces ran a full-size complex FFT over real input, and simd's
-// f64.STFTPlan (evaluated at v1.5.0, and the reference these tests still
-// compare against) halves that but leaves the butterfly scalar. Measured on an
-// i7-1260P at nfft=1024, this package is about 1.6x f64.STFTPlan.
+// f64.STFTPlan (still the reference these tests compare against) halves that
+// but leaves its own butterfly scalar. BenchmarkPowerInto measures the gap;
+// run it rather than trusting a figure quoted here, which rots.
 //
-// simd#192 tracks vectorizing that butterfly and adding the f64 kernels this
-// would need; f64 currently exports no ButterflyComplex or RealFFTUnpack at
-// all, so composing simd primitives was not an option for a float64 consumer.
-// Once #192 lands, this package should shrink back to a thin call into simd,
-// so the API here is deliberately the minimum the renderer needs (a single
-// frame, no framing or padding modes) rather than a general STFT.
+// simd#192 has since landed f64.ButterflyComplex and f64.RealFFTUnpack, and
+// this package uses the first of them: see stage2 and kernelSpanMin for which
+// stages go through the kernel and why the small spans do not. The second is
+// deliberately NOT used; unravelPower explains what it measured.
+//
+// What remains before this package could collapse into a thin call into simd
+// is filed as simd#198 (a stage-level butterfly, and a real-FFT unpack that
+// writes power directly). The API here is therefore still the minimum the
+// renderer needs (a single frame, no framing or padding modes) rather than a
+// general STFT.
 //
 // The transform is the standard real-input trick: an nfft-point real sequence
 // is packed into an nfft/2-point complex sequence (evens into the real part,
@@ -26,6 +30,8 @@ import (
 	"fmt"
 	"math"
 	"math/bits"
+
+	"github.com/tphakala/simd/f64"
 )
 
 // ErrUnsupportedSize is returned by NewPlan when nfft is not a power of two, or
@@ -33,6 +39,40 @@ import (
 // condition alone: nfft == 2 is a power of two and is still rejected, because
 // the packed transform needs at least two complex points.
 var ErrUnsupportedSize = errors.New("fft: size must be a power of two >= 4")
+
+// stage holds one pass of the transform: its radix, the span it operates at,
+// and its twiddles laid out contiguously by j rather than read at stride from
+// one shared table.
+//
+// The twiddles a butterfly needs are W^t, W^2t and W^3t at t = j*step, so a
+// shared table is walked at stride step, 2*step and 3*step. Those strides are
+// what the loop was spending its loads on: the values depend only on j and the
+// stage, never on the frame, so they are resolved once at plan time into
+// sequential arrays. Total extra memory is a little over 2*half float64 across
+// all stages. A radix-2 stage uses only the first pair.
+type stage struct {
+	radix    int
+	span     int
+	w1r, w1i []float64
+	w2r, w2i []float64
+	w3r, w3i []float64
+}
+
+// kernelSpanMin is the span from which a stage switches from the scalar radix-4
+// butterfly to simd's vectorized radix-2 one.
+//
+// f64.ButterflyComplex takes one contiguous run of pairs, so a stage at span s
+// costs half/(2s) calls, and below a certain span the per-call overhead is
+// larger than the butterflies themselves. Measured on an i7-1260P over a
+// half of 1024, per stage: the kernel is 9.7x the scalar radix-2 loop at span
+// 512 but only 1.3x at span 4, while one scalar radix-4 stage does the work of
+// two radix-2 stages for well under twice the cost. Comparing like for like,
+// radix 4 wins below span 16 and the kernel wins from there up.
+//
+// A stage-level kernel (one call per stage, taking the span) would remove the
+// trade entirely and is worth asking simd for; it would make the small spans as
+// fast per butterfly as the large ones.
+const kernelSpanMin = 8
 
 // Plan holds the resident twiddle tables and scratch for a fixed transform
 // size. Reuse one across frames to stay allocation-free.
@@ -43,21 +83,29 @@ type Plan struct {
 	nfft int
 	half int // nfft/2: the size of the packed complex transform
 
-	// radices lists the transform stages in the order they are applied, from
-	// the smallest span outwards. Radix 4 does the same work as two radix-2
-	// stages in one pass over the scratch, with three quarters of the complex
-	// multiplies, so the decomposition is all 4s with a single leading 2 when
-	// log2(half) is odd.
-	radices []int
+	// leadRadix2 records that the decomposition needs a radix-2 pass, which
+	// happens exactly when log2(half) is odd. Radix 4 does the same work as two
+	// radix-2 stages in one pass over the scratch, with three quarters of the
+	// complex multiplies, so the decomposition is all 4s with a single leading 2
+	// when it cannot be all 4s.
+	//
+	// Either way the leading pass runs at span 1, where every twiddle is W^0 = 1
+	// and no complex multiply is needed at all. That is why it is not in stages:
+	// pack fuses it into the load (see packStage), which both skips the
+	// multiplies and saves a whole read-modify-write pass over the scratch.
+	leadRadix2 bool
 
-	// perm is the mixed-radix digit reversal for radices, applied during the
-	// load so the stages can run in place with no separate reorder pass.
-	perm []int32
+	// stages lists the radix-4 passes after the fused leading one, from the
+	// smallest span outwards.
+	stages []stage
 
-	// Twiddles for the size-half complex FFT, twRe[t] = cos(2*pi*t/half) and
-	// twIm[t] = -sin(2*pi*t/half). Radix 4 reaches 3*j*step, so unlike a
-	// purely radix-2 table this must span the full [0, half).
-	twRe, twIm []float64
+	// iperm[d] is the source index whose sample belongs at scratch position d,
+	// the inverse of the mixed-radix digit reversal that decimation in time
+	// expects. It is the inverse rather than the forward map so that pack can
+	// gather: the leading butterfly consumes four (or two) consecutive
+	// destinations at a time, and writing them sequentially is what lets the
+	// leading stage be fused into the load in the first place.
+	iperm []int32
 
 	// Unravel twiddles W_N^k = exp(-2*pi*i*k/nfft) for k in [0, half].
 	unRe, unIm []float64
@@ -75,33 +123,25 @@ func NewPlan(nfft int) (*Plan, error) {
 	half := nfft >> 1
 
 	p := &Plan{
-		nfft: nfft,
-		half: half,
-		perm: make([]int32, half),
-		twRe: make([]float64, half),
-		twIm: make([]float64, half),
-		unRe: make([]float64, half+1),
-		unIm: make([]float64, half+1),
-		re:   make([]float64, half),
-		im:   make([]float64, half),
+		nfft:  nfft,
+		half:  half,
+		iperm: make([]int32, half),
+		unRe:  make([]float64, half+1),
+		unIm:  make([]float64, half+1),
+		re:    make([]float64, half),
+		im:    make([]float64, half),
 	}
 
 	// half is a power of two, so its trailing-zero count is log2(half).
 	logHalf := bits.TrailingZeros(uint(half))
-	if logHalf%2 == 1 {
-		p.radices = append(p.radices, 2)
-	}
-	for r := logHalf % 2; r < logHalf; r += 2 {
-		p.radices = append(p.radices, 4)
-	}
-	p.buildPerm()
+	p.leadRadix2 = logHalf%2 == 1
+
+	radices := decompose(logHalf)
+	p.buildIPerm(radices)
+	p.buildStages(radices)
 
 	// Twiddles are evaluated in float64 from the exact angle, matching the
 	// reference implementation this replaces bit for bit.
-	for t := range p.twRe {
-		s, c := math.Sincos(2 * math.Pi * float64(t) / float64(half))
-		p.twRe[t], p.twIm[t] = c, -s
-	}
 	for k := 0; k <= half; k++ {
 		s, c := math.Sincos(2 * math.Pi * float64(k) / float64(nfft))
 		p.unRe[k], p.unIm[k] = c, -s
@@ -110,8 +150,38 @@ func NewPlan(nfft int) (*Plan, error) {
 	return p, nil
 }
 
-// buildPerm fills perm with the mixed-radix digit reversal that decimation in
-// time expects.
+// decompose chooses the radix of each pass, from the smallest span outwards,
+// for a transform of size 2^logHalf.
+//
+// Radix 4 does the same work as two radix-2 stages in one pass over the
+// scratch, with three quarters of the complex multiplies, so it is the better
+// scalar choice and the decomposition starts with it. It only fits an even
+// number of remaining halvings, hence the leading radix-2 when logHalf is odd;
+// that leading pass runs at span 1 where every twiddle is 1, so it is the
+// cheapest place to put it. From kernelSpanMin the passes switch to radix 2,
+// because that is the shape simd's vectorized butterfly takes and from that
+// span it is worth far more than the multiplies radix 4 saves.
+func decompose(logHalf int) []int {
+	var radices []int
+	span, left := 1, logHalf
+	if left%2 == 1 {
+		radices = append(radices, 2)
+		span, left = 2, left-1
+	}
+	for left > 0 {
+		if left >= 2 && span < kernelSpanMin {
+			radices = append(radices, 4)
+			span, left = span*4, left-2
+			continue
+		}
+		radices = append(radices, 2)
+		span, left = span*2, left-1
+	}
+	return radices
+}
+
+// buildIPerm fills iperm with the inverse of the mixed-radix digit reversal
+// that decimation in time expects.
 //
 // The digit weights run opposite to the order the stages are applied: the stage
 // with span 1 corresponds to the LAST factor of the decimation, so the index is
@@ -119,14 +189,17 @@ func NewPlan(nfft int) (*Plan, error) {
 // in the opposite order. For an all-radix-2 decomposition this reduces to plain
 // bit reversal, and when every radix is equal the direction cannot be observed
 // at all, which is why only a mixed decomposition such as [2 4 4] pins it down.
-func (p *Plan) buildPerm() {
-	n := len(p.radices)
+//
+// Digit reversal is an involution only when all the radices are equal, so the
+// inverse is stored explicitly rather than assumed symmetric.
+func (p *Plan) buildIPerm(radices []int) {
+	n := len(radices)
 	rad := make([]int, n)
-	for d, r := range p.radices {
+	for d, r := range radices {
 		rad[n-1-d] = r
 	}
 	digits := make([]int, n)
-	for i := range p.perm {
+	for i := range p.iperm {
 		v := i
 		for d := range n {
 			digits[d] = v % rad[d]
@@ -136,7 +209,42 @@ func (p *Plan) buildPerm() {
 		for d := range n {
 			r = r*rad[d] + digits[d]
 		}
-		p.perm[i] = int32(r)
+		p.iperm[r] = int32(i)
+	}
+}
+
+// buildStages resolves the per-stage twiddle tables for every pass after the
+// fused leading one.
+func (p *Plan) buildStages(radices []int) {
+	// Span after the leading pass: 2 for a radix-2 lead, 4 otherwise.
+	span := radices[0]
+	// tw returns the shared twiddle W^t = exp(-2*pi*i*t/half), evaluated from
+	// the exact angle so the values are identical to a strided read of one
+	// table built the same way.
+	tw := func(t int) (re, im float64) {
+		s, c := math.Sincos(2 * math.Pi * float64(t) / float64(p.half))
+		return c, -s
+	}
+	for _, r := range radices[1:] {
+		step := p.half / (span * r)
+		st := stage{
+			radix: r, span: span,
+			w1r: make([]float64, span), w1i: make([]float64, span),
+		}
+		if r == 4 {
+			st.w2r, st.w2i = make([]float64, span), make([]float64, span)
+			st.w3r, st.w3i = make([]float64, span), make([]float64, span)
+		}
+		for j := range span {
+			t := j * step
+			st.w1r[j], st.w1i[j] = tw(t)
+			if r == 4 {
+				st.w2r[j], st.w2i[j] = tw(2 * t)
+				st.w3r[j], st.w3i[j] = tw(3 * t)
+			}
+		}
+		p.stages = append(p.stages, st)
+		span *= r
 	}
 }
 
@@ -161,65 +269,109 @@ func (p *Plan) PowerInto(dst, signal, window []float64) {
 		panic(fmt.Sprintf("fft: PowerInto: nfft %d needs dst >= %d, signal >= %d, window >= %d (nil ok); got %d, %d, %d",
 			p.nfft, p.half+1, p.nfft, p.nfft, len(dst), len(signal), len(window)))
 	}
-	p.pack(signal, window)
+	p.packStage(signal, window)
 	p.transform()
 	p.unravelPower(dst)
 }
 
-// pack loads the frame as half complex samples c[j] = x[2j] + i*x[2j+1],
-// applying the window on the way in, and applies the bit-reversal permutation
-// so the transform can run in place.
-func (p *Plan) pack(signal, window []float64) {
-	re, im, br := p.re[:p.half], p.im[:p.half], p.perm
-	src := signal[:2*len(br)]
+// packStage loads the frame as half complex samples c[j] = x[2j] + i*x[2j+1],
+// applying the window on the way in, permuting into digit-reversed order, and
+// applying the leading twiddle-free butterfly, all in one pass.
+//
+// The load is a gather rather than a scatter: it walks the destination in
+// order, pulling each sample from iperm. That is what makes fusing the leading
+// stage possible, since one butterfly's outputs are consecutive destinations,
+// and it keeps every store sequential.
+func (p *Plan) packStage(signal, window []float64) {
+	re, im, ip := p.re[:p.half], p.im[:p.half], p.iperm[:p.half]
+	src := signal[:2*len(ip)]
+
 	if window == nil {
-		for j, r := range br {
-			s := src[2*j : 2*j+2 : 2*j+2]
-			re[r] = s[0]
-			im[r] = s[1]
+		if p.leadRadix2 {
+			for q := 0; q+2 <= len(re); q += 2 {
+				a, b := 2*int(ip[q]), 2*int(ip[q+1])
+				ar, ai := src[a], src[a+1]
+				br, bi := src[b], src[b+1]
+				re[q], im[q] = ar+br, ai+bi
+				re[q+1], im[q+1] = ar-br, ai-bi
+			}
+			return
+		}
+		for q := 0; q+4 <= len(re); q += 4 {
+			a, b := 2*int(ip[q]), 2*int(ip[q+1])
+			c, d := 2*int(ip[q+2]), 2*int(ip[q+3])
+			ar, ai := src[a], src[a+1]
+			br, bi := src[b], src[b+1]
+			cr, ci := src[c], src[c+1]
+			dr, di := src[d], src[d+1]
+			t0r, t0i := ar+cr, ai+ci
+			t1r, t1i := ar-cr, ai-ci
+			t2r, t2i := br+dr, bi+di
+			t3r, t3i := br-dr, bi-di
+			re[q], im[q] = t0r+t2r, t0i+t2i
+			re[q+2], im[q+2] = t0r-t2r, t0i-t2i
+			re[q+1], im[q+1] = t1r+t3i, t1i-t3r
+			re[q+3], im[q+3] = t1r-t3i, t1i+t3r
 		}
 		return
 	}
-	w := window[:2*len(br)]
-	for j, r := range br {
-		s := src[2*j : 2*j+2 : 2*j+2]
-		ww := w[2*j : 2*j+2 : 2*j+2]
-		re[r] = s[0] * ww[0]
-		im[r] = s[1] * ww[1]
-	}
-}
 
-// transform runs an in-place decimation-in-time complex FFT of size half over
-// the scratch, which pack has already left in digit-reversed order.
-func (p *Plan) transform() {
-	span := 1
-	for _, r := range p.radices {
-		if r == 2 {
-			// stage2 hardcodes span 1 (see its doc); a radix-2 anywhere but
-			// first would silently produce a wrong transform, so assert rather
-			// than trust the construction in NewPlan.
-			if span != 1 {
-				panic("fft: radix-2 stage at span > 1")
-			}
-			p.stage2()
-		} else {
-			p.stage4(span)
+	w := window[:2*len(ip)]
+	if p.leadRadix2 {
+		for q := 0; q+2 <= len(re); q += 2 {
+			a, b := 2*int(ip[q]), 2*int(ip[q+1])
+			ar, ai := src[a]*w[a], src[a+1]*w[a+1]
+			br, bi := src[b]*w[b], src[b+1]*w[b+1]
+			re[q], im[q] = ar+br, ai+bi
+			re[q+1], im[q+1] = ar-br, ai-bi
 		}
-		span *= r
+		return
+	}
+	for q := 0; q+4 <= len(re); q += 4 {
+		a, b := 2*int(ip[q]), 2*int(ip[q+1])
+		c, d := 2*int(ip[q+2]), 2*int(ip[q+3])
+		ar, ai := src[a]*w[a], src[a+1]*w[a+1]
+		br, bi := src[b]*w[b], src[b+1]*w[b+1]
+		cr, ci := src[c]*w[c], src[c+1]*w[c+1]
+		dr, di := src[d]*w[d], src[d+1]*w[d+1]
+		t0r, t0i := ar+cr, ai+ci
+		t1r, t1i := ar-cr, ai-ci
+		t2r, t2i := br+dr, bi+di
+		t3r, t3i := br-dr, bi-di
+		re[q], im[q] = t0r+t2r, t0i+t2i
+		re[q+2], im[q+2] = t0r-t2r, t0i-t2i
+		re[q+1], im[q+1] = t1r+t3i, t1i-t3r
+		re[q+3], im[q+3] = t1r-t3i, t1i+t3r
 	}
 }
 
-// stage2 applies the single radix-2 stage that a decomposition needs when
-// log2(half) is odd. It is always the first stage, so its span is 1 and the
-// only twiddle it could use is W^0 = 1: the complex multiply is skipped
-// entirely and each butterfly is one complex add and one complex subtract.
-func (p *Plan) stage2() {
-	re, im := p.re, p.im
-	for k := 0; k < len(re); k += 2 {
-		ar, ai := re[k], im[k]
-		br, bi := re[k+1], im[k+1]
-		re[k], im[k] = ar+br, ai+bi
-		re[k+1], im[k+1] = ar-br, ai-bi
+// transform runs the radix-4 stages that packStage did not already apply, in
+// place over the scratch.
+func (p *Plan) transform() {
+	for i := range p.stages {
+		if s := &p.stages[i]; s.radix == 2 {
+			p.stage2(s)
+		} else {
+			p.stage4(s)
+		}
+	}
+}
+
+// stage2 applies one radix-2 decimation-in-time stage through simd's
+// vectorized butterfly, which is exactly this operation over a contiguous run
+// of pairs: temp = lower*W, then lower = upper-temp and upper = upper+temp.
+//
+// One call per block is what the kernel's shape allows, so this is only used
+// from kernelSpanMin up, where the runs are long enough for that to pay.
+func (p *Plan) stage2(s *stage) {
+	re, im := p.re[:p.half], p.im[:p.half]
+	span := s.span
+	m := span * 2
+	for k := 0; k+m <= len(re); k += m {
+		f64.ButterflyComplex(
+			re[k:k+span:k+span], im[k:k+span:k+span],
+			re[k+span:k+m:k+m], im[k+span:k+m:k+m],
+			s.w1r, s.w1i)
 	}
 }
 
@@ -233,11 +385,16 @@ func (p *Plan) stage2() {
 //
 // which is why the two cross terms need no multiply: rotating by -i is a swap
 // of real and imaginary parts with one sign flip.
-func (p *Plan) stage4(span int) {
+func (p *Plan) stage4(s *stage) {
 	re, im := p.re[:p.half], p.im[:p.half]
+	span := s.span
 	m := span * 4
-	step := p.half / m
-	twRe, twIm := p.twRe[:p.half], p.twIm[:p.half]
+	// Slicing every twiddle array to exactly span is what proves w1r[j] and its
+	// siblings in range for the inner loop, which ranges over a slice of that
+	// same length.
+	w1r, w1i := s.w1r[:span], s.w1i[:span]
+	w2r, w2i := s.w2r[:span], s.w2i[:span]
+	w3r, w3i := s.w3r[:span], s.w3i[:span]
 	for k := 0; k+m <= len(re); k += m {
 		r0 := re[k : k+span : k+span]
 		r1 := re[k+span : k+2*span : k+2*span]
@@ -250,17 +407,12 @@ func (p *Plan) stage4(span int) {
 		for j := range r0 {
 			ar, ai := r0[j], m0[j]
 
-			t := j * step
-			w1r, w1i := twRe[t], twIm[t]
-			w2r, w2i := twRe[2*t], twIm[2*t]
-			w3r, w3i := twRe[3*t], twIm[3*t]
-
-			br := w1r*r1[j] - w1i*m1[j]
-			bi := w1r*m1[j] + w1i*r1[j]
-			cr := w2r*r2[j] - w2i*m2[j]
-			ci := w2r*m2[j] + w2i*r2[j]
-			dr := w3r*r3[j] - w3i*m3[j]
-			di := w3r*m3[j] + w3i*r3[j]
+			br := w1r[j]*r1[j] - w1i[j]*m1[j]
+			bi := w1r[j]*m1[j] + w1i[j]*r1[j]
+			cr := w2r[j]*r2[j] - w2i[j]*m2[j]
+			ci := w2r[j]*m2[j] + w2i[j]*r2[j]
+			dr := w3r[j]*r3[j] - w3i[j]*m3[j]
+			di := w3r[j]*m3[j] + w3i[j]*r3[j]
 
 			t0r, t0i := ar+cr, ai+ci
 			t1r, t1i := ar-cr, ai-ci
@@ -289,6 +441,14 @@ func (p *Plan) stage4(span int) {
 //	X[half-k] = ( E.r + v.r*O.r + v.i*O.i,  -E.i - v.r*O.i + v.i*O.r )
 //
 // with w the unravel twiddle at k and v the one at half-k.
+//
+// f64.RealFFTUnpack (simd v1.6.0) is the vectorized form of this
+// recombination, and it loses to this loop: measured on an idle i7-1260P at a
+// fixed clock, +39% at nfft 256, +15% at 512, level at 1024 and +4% at 2048.
+// It writes the complex half-spectrum, so squaring it into power costs two
+// further passes over the bins, and that traffic is worth more here than the
+// vector lanes. A kernel that wrote |X_k|^2 directly would flip the result;
+// that is the shape to ask simd for.
 func (p *Plan) unravelPower(dst []float64) {
 	half := p.half
 	re, im := p.re[:half], p.im[:half]
@@ -331,4 +491,18 @@ func (p *Plan) unravelPower(dst []float64) {
 		xi := ei + (wr*oi + wi*or)
 		dst[h] = xr*xr + xi*xi
 	}
+}
+
+// Clone returns a plan for the same size that shares this one's twiddle tables
+// and permutation but carries its own scratch, so the two can transform
+// concurrently.
+//
+// The shared state is written once in NewPlan and only read afterwards. Cloning
+// exists because building a plan costs a few thousand Sincos calls, which is a
+// real fraction of a single spectrogram; a clone costs two allocations.
+func (p *Plan) Clone() *Plan {
+	c := *p
+	c.re = make([]float64, p.half)
+	c.im = make([]float64, p.half)
+	return &c
 }

--- a/internal/fft/fft_test.go
+++ b/internal/fft/fft_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/cmplx"
+	"sync"
 	"testing"
 
 	"github.com/tphakala/simd/f64"
@@ -446,4 +447,103 @@ func FuzzPowerInto(f *testing.F) {
 			}
 		}
 	})
+}
+
+// TestCloneMatchesOriginal pins Clone's contract: a clone shares the parent's
+// twiddle tables but carries its own scratch, so it must produce bit-identical
+// output. Bit-identical rather than approximately equal, because the renderer's
+// parity with the sox binary is exact and a clone is what every worker beyond
+// the first one uses.
+func TestCloneMatchesOriginal(t *testing.T) {
+	for nfft := 4; nfft <= 2048; nfft <<= 1 {
+		p, err := NewPlan(nfft)
+		if err != nil {
+			t.Fatalf("nfft %d: %v", nfft, err)
+		}
+		sig := make([]float64, nfft)
+		win := make([]float64, nfft)
+		for i := range sig {
+			sig[i] = math.Sin(2*math.Pi*3*float64(i)/float64(nfft)) + 0.25*math.Cos(float64(i))
+			win[i] = 0.5 - 0.5*math.Cos(2*math.Pi*float64(i)/float64(nfft-1))
+		}
+		want := make([]float64, p.NumBins())
+		p.PowerInto(want, sig, win)
+
+		c := p.Clone()
+		got := make([]float64, c.NumBins())
+		c.PowerInto(got, sig, win)
+
+		if c.NFFT() != p.NFFT() || c.NumBins() != p.NumBins() {
+			t.Fatalf("nfft %d: clone reports size %d/%d, original %d/%d",
+				nfft, c.NFFT(), c.NumBins(), p.NFFT(), p.NumBins())
+		}
+		for k := range want {
+			if got[k] != want[k] {
+				t.Fatalf("nfft %d bin %d: clone %v, original %v (must be bit-identical)",
+					nfft, k, got[k], want[k])
+			}
+		}
+		// Interleaving the two plans must not disturb either. This is a
+		// weaker check than it looks: PowerInto repacks the whole scratch on
+		// every call, so a clone that wrongly SHARED the scratch would still
+		// pass here. Sequential use cannot distinguish the two; only
+		// concurrent use can, which is what TestCloneIsRaceFree covers.
+		again := make([]float64, p.NumBins())
+		p.PowerInto(again, sig, win)
+		for k := range want {
+			if again[k] != want[k] {
+				t.Fatalf("nfft %d bin %d: original returned %v on a repeat run, first run gave %v",
+					nfft, k, again[k], want[k])
+			}
+		}
+	}
+}
+
+// TestCloneIsRaceFree runs a plan and several clones concurrently over the same
+// read-only inputs. It exists to be run under -race: sharing the twiddle tables
+// is the whole point of Clone, and a table that turned out to be written during
+// a transform would be a data race in every parallel render.
+func TestCloneIsRaceFree(t *testing.T) {
+	const nfft = 512
+	p, err := NewPlan(nfft)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig := make([]float64, nfft)
+	win := make([]float64, nfft)
+	for i := range sig {
+		sig[i] = math.Sin(float64(i))
+		win[i] = 1
+	}
+	want := make([]float64, p.NumBins())
+	p.PowerInto(want, sig, win)
+
+	plans := []*Plan{p}
+	for range 7 {
+		plans = append(plans, p.Clone())
+	}
+	var wg sync.WaitGroup
+	errs := make([]bool, len(plans))
+	for i, pl := range plans {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			dst := make([]float64, pl.NumBins())
+			for range 50 {
+				pl.PowerInto(dst, sig, win)
+				for k := range want {
+					if dst[k] != want[k] {
+						errs[i] = true
+						return
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	for i, bad := range errs {
+		if bad {
+			t.Errorf("plan %d produced a different spectrum when run concurrently", i)
+		}
+	}
 }

--- a/sox/analyzer.go
+++ b/sox/analyzer.go
@@ -2,187 +2,416 @@ package sox
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/tphakala/go-spectrogram/internal/fft"
 	"github.com/tphakala/simd/f64"
 )
 
-// analyzer reproduces SoX's streaming spectrogram accumulation. dBfs is stored
-// column-major: dBfs[col*rows + row], row 0 = DC. max tracks the brightest
-// pre-gain dBFS (for -n normalize) and starts at -dBRange.
-type analyzer struct {
+// analyzerOpts is what the analysis needs from the resolved Options and the
+// geometry derived from them. It is a struct rather than a parameter list
+// because that list had grown to ten positional values, most of them ints,
+// where transposing two of them is a wrong image rather than a compile error.
+type analyzerOpts struct {
 	dftSize, rows        int
 	stepSize, blockSteps int
 	blockNorm            float64
 	gain                 int // SoX p->gain = -opt.Gain
 	dBRange              int
-	ws                   *windowState
+	spectrumPoints       int
 	xSize                int
+	normalize            bool // SoX -n
+	window               WindowType
+	workers              int // goroutines to spread the columns over; >= 1
+}
 
-	plan *fft.Plan
-	buf  []float64 // len dftSize
-	pow  []float64 // per-block power spectrum scratch, len rows
-	db   []float64 // per-column dB scratch, len rows
-	mag  []float64 // len rows
+// blockPlan is one DFT: where its frame starts in the padded input stream, and
+// the window `end` SoX's state machine had reached when it ran.
+//
+// start is a position in the stream SoX effectively transforms, which is the
+// input with zeros before the first sample and after the last: the leading pad
+// is what centres the first frame, the trailing pad is what the drain flushes
+// with. It is therefore signed, and can also run past the end of the input.
+type blockPlan struct {
+	start int
+	end   int
+}
 
-	read      int
-	end       int
-	endMin    int
-	lastEnd   int
-	blockNum  int
-	cols      int
-	truncated bool
+// columnPlan is one output column: the run of blocks whose power it sums, and
+// the normalisation SoX applies to that sum. norm is per column because the
+// last one can cover fewer blocks than the rest and is rescaled to match.
+type columnPlan struct {
+	firstBlock int
+	nBlocks    int
+	norm       float64
+}
 
-	dBfs []float32
+// analysis is the finished spectrogram data for an image.
+//
+// Output is column-major (column c occupies [c*rows : (c+1)*rows], row 0 = DC)
+// and takes one of two forms. By default each cell is resolved to a palette
+// index in idx as its column is computed, while that column's dB values are
+// still in L1: a quarter of the bytes of the dBFS form, and it leaves Render's
+// raster pass a plain byte transpose rather than a strided float32 read with a
+// quantisation per pixel.
+//
+// With -n normalize the mapping depends on the brightest cell in the whole
+// image, which is not known until every column is done, so the raw dBFS values
+// go to dBfs and quantise resolves them afterwards. max, the brightest pre-gain
+// dBFS, is only maintained in that case; it stays at its -dBRange seed
+// otherwise.
+type analysis struct {
+	opts analyzerOpts
+	cols int
+
+	idx  []uint8   // palette indices, default path
+	dBfs []float32 // raw dBFS, -n normalize path
 	max  float64
 }
 
-func newAnalyzer(dftSize, rows, stepSize, blockSteps int, blockNorm float64, gain, dBRange int, ws *windowState, xSize int) (*analyzer, error) {
+// analyze renders every column of the spectrogram for samples.
+//
+// It runs in two phases. The first walks SoX's streaming state machine to
+// decide what each column is made of; the second computes the columns, over as
+// many goroutines as opts.workers allows. Splitting it this way is what makes
+// the transform parallelisable at all: SoX's accumulation is sequential state
+// (a sliding buffer, a window that reshapes at both ends of the clip, a
+// truncation rule, and a renormalised final column), so the schedule is derived
+// by running that state machine rather than by re-deriving closed forms for it,
+// which is how a parallel port drifts from the original. What comes out is a
+// plan whose columns are independent and can be computed in any order.
+func analyze(o analyzerOpts, samples []float32) (*analysis, error) {
 	// dftSize is a power of two by construction (validate() rejects YSize values
 	// that do not yield one), so this only fails on a programming error.
-	plan, err := fft.NewPlan(dftSize)
+	plan, err := fft.NewPlan(o.dftSize)
 	if err != nil {
 		return nil, err
 	}
 	// deriveDFTSize always returns rows == dftSize/2+1, which is exactly the
 	// plan's bin count. Assert it anyway: rows sizes every per-column buffer
-	// here, and the simd reductions in doColumn silently process only
+	// here, and the simd reductions in finishColumn silently process only
 	// min(len(dst), len(src)) elements, so a mismatch would quietly truncate
 	// each column rather than fail.
-	if rows != plan.NumBins() {
+	if o.rows != plan.NumBins() {
 		return nil, fmt.Errorf("sox: rows %d does not match DFT bin count %d for size %d",
-			rows, plan.NumBins(), dftSize)
+			o.rows, plan.NumBins(), o.dftSize)
 	}
-	// The window is sliced to dftSize on every block, so check it once here
-	// rather than panicking in the hot loop. Check the shape too, not just the
-	// length: makeWindow derives the taper from ws.dftSize, so a state built
-	// for a larger size is long enough to pass a length check while producing
-	// the wrong window.
-	if ws == nil || ws.dftSize != dftSize || len(ws.window) < dftSize {
-		return nil, fmt.Errorf("sox: window state is not sized for DFT size %d", dftSize)
+
+	blocks, columns := schedule(o, len(samples))
+	a := &analysis{opts: o, cols: len(columns), max: -float64(o.dBRange)}
+	n := a.cols * o.rows
+	if o.normalize {
+		a.dBfs = make([]float32, n)
+	} else {
+		a.idx = make([]uint8, n)
 	}
-	a := &analyzer{
-		dftSize: dftSize, rows: rows,
-		stepSize: stepSize, blockSteps: blockSteps, blockNorm: blockNorm,
-		gain: gain, dBRange: dBRange, ws: ws, xSize: xSize,
-		plan: plan,
-		buf:  make([]float64, dftSize),
-		pow:  make([]float64, rows),
-		db:   make([]float64, rows),
-		mag:  make([]float64, rows),
-		// Columns are bounded by xSize; pre-size dBfs to avoid repeated grow/copy
-		// in doColumn (cap only, length stays 0 and grows by append).
-		dBfs: make([]float32, 0, xSize*rows),
+	if a.cols == 0 {
+		return a, nil
 	}
-	a.end = dftSize                   // spectrogram.c:429
-	a.endMin = 0                      // zeroed in start
-	a.lastEnd = 0                     // make_window(p, 0) already done before loop
-	a.max = -float64(dBRange)         // spectrogram.c:443
-	a.read = (stepSize - dftSize) / 2 // spectrogram.c:444 (negative)
+
+	workers := min(max(o.workers, 1), a.cols)
+	if workers == 1 {
+		r := a.newRenderer(plan)
+		r.run(samples, blocks, columns, 0, a.cols)
+		a.max = r.max
+		return a, nil
+	}
+
+	// Static partitioning: every column costs the same number of DFTs, so
+	// there is nothing for a work queue to balance. Ranges are contiguous
+	// because a renderer slides its frame buffer and reshapes its window only
+	// when `end` changes, both of which are only cheap along a run of columns.
+	rs := make([]*columnRenderer, workers)
+	per := (a.cols + workers - 1) / workers
+	var wg sync.WaitGroup
+	for w := range workers {
+		from, to := w*per, min((w+1)*per, a.cols)
+		if from >= to {
+			break
+		}
+		// The first worker takes the plan just built; the rest clone it, sharing
+		// its twiddle tables and allocating only their own scratch.
+		p := plan
+		if w > 0 {
+			p = plan.Clone()
+		}
+		r := a.newRenderer(p)
+		rs[w] = r
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.run(samples, blocks, columns, from, to)
+		}()
+	}
+	wg.Wait()
+	for _, r := range rs {
+		if r != nil && r.max > a.max {
+			a.max = r.max
+		}
+	}
 	return a, nil
 }
 
-// run feeds all samples then drains, returning the number of columns produced.
-func (a *analyzer) run(samples []float32) int {
-	a.flow(samples)
-	a.drain()
-	return a.cols
+// scheduler walks SoX's streaming accumulation without touching any audio,
+// recording which frames each output column is built from. Its arithmetic is
+// the original flow/drain loop (spectrogram.c:497-566) with the sample copies
+// and the transform removed.
+type scheduler struct {
+	dftSize, stepSize, blockSteps, xSize int
+	blockNorm                            float64
+
+	read      int
+	end       int
+	endMin    int
+	blockNum  int
+	fed       int // samples pushed into the sliding buffer so far
+	truncated bool
+
+	blocks  []blockPlan
+	columns []columnPlan
 }
 
-// flow ports spectrogram.c:497-531. `in` may be float32 (audio) fed as float64.
-func (a *analyzer) flow(in []float32) {
-	idx, n := 0, len(in)
-	for !a.truncated {
-		if a.read == a.stepSize {
-			copy(a.buf[:a.dftSize-a.stepSize], a.buf[a.stepSize:a.dftSize])
-			a.read = 0
+func schedule(o analyzerOpts, nSamples int) (blocks []blockPlan, columns []columnPlan) {
+	s := &scheduler{
+		dftSize: o.dftSize, stepSize: o.stepSize,
+		blockSteps: o.blockSteps, xSize: o.xSize,
+		blockNorm: o.blockNorm,
+	}
+	s.end = o.dftSize                     // spectrogram.c:429
+	s.endMin = 0                          // zeroed in start
+	s.read = (o.stepSize - o.dftSize) / 2 // spectrogram.c:444 (negative)
+	s.flow(nSamples)
+	s.drain()
+	return s.blocks, s.columns
+}
+
+// flow ports spectrogram.c:497-531 for n further samples. The sliding buffer
+// always holds the last dftSize samples pushed, so a block's frame is fixed by
+// how many have been pushed when it fires, and only that count is tracked here.
+func (s *scheduler) flow(n int) {
+	idx := 0
+	for !s.truncated {
+		if s.read == s.stepSize {
+			s.read = 0
 		}
-		// Fill in bulk: this loop sees every sample in the clip, so the copy is
-		// shaped to keep the compiler's bounds checks out of it.
-		if k := min(n-idx, a.stepSize-a.read); k > 0 {
-			src := in[idx : idx+k]
-			dst := a.buf[a.dftSize-a.stepSize+a.read:]
-			dst = dst[:len(src)] // BCE hint: dst[i] is provably in range below
-			for i, v := range src {
-				dst[i] = float64(v)
-			}
+		if k := min(n-idx, s.stepSize-s.read); k > 0 {
 			idx += k
-			a.read += k
-			a.end -= k
+			s.read += k
+			s.end -= k
+			s.fed += k
 		}
-		if a.read != a.stepSize {
+		if s.read != s.stepSize {
 			break
 		}
-		a.processBlock()
+		s.processBlock()
 	}
 }
 
-// processBlock windows, FFTs, accumulates magnitudes, and emits a column every
-// blockSteps DFTs.
-func (a *analyzer) processBlock() {
-	if a.end < a.endMin {
-		a.end = a.endMin
+func (s *scheduler) processBlock() {
+	if s.end < s.endMin {
+		s.end = s.endMin
 	}
-	if a.end != a.lastEnd {
-		makeWindow(a.ws, a.end)
-		a.lastEnd = a.end
-	}
-	// One frame: the fused real-input transform windows, transforms, and squares
-	// in a single pass, at half the complex FFT size. It runs in float64 to
-	// match SoX's own double-precision lsx_rdft.
-	//
-	// pow[k] is |X_k|^2 for k in [0, dftSize/2]. DC and Nyquist are purely real
-	// for a real-input transform, so they agree with SoX's real-only
-	// accumulation at those two bins.
-	a.plan.PowerInto(a.pow, a.buf, a.ws.window)
-	f64.Add(a.mag, a.mag, a.pow)
-
-	a.blockNum++
-	if a.blockNum == a.blockSteps {
-		a.doColumn()
+	s.blocks = append(s.blocks, blockPlan{start: s.fed - s.dftSize, end: s.end})
+	s.blockNum++
+	if s.blockNum == s.blockSteps {
+		s.doColumn()
 	}
 }
 
 // doColumn ports spectrogram.c:449-475 (non-truncate variant).
-func (a *analyzer) doColumn() {
-	if a.cols == a.xSize {
-		a.truncated = true
+func (s *scheduler) doColumn() {
+	if len(s.columns) == s.xSize {
+		s.truncated = true
 		return
 	}
-	a.cols++
-	// dBfs = 10*log10(mag*blockNorm), vectorized over the whole column: a
-	// per-cell math.Log10 would be over half a million calls for a
-	// default-sized image.
-	f64.Scale(a.db, a.mag, a.blockNorm)
-	f64.Log10(a.db, a.db)
-	f64.Scale(a.db, a.db, 10)
-
-	gain := float64(a.gain)
-	for _, dBfs := range a.db[:a.rows] {
-		a.dBfs = append(a.dBfs, float32(dBfs+gain))
-		if dBfs > a.max {
-			a.max = dBfs
-		}
-	}
-	clear(a.mag)
-	a.blockNum = 0
+	s.columns = append(s.columns, columnPlan{
+		firstBlock: len(s.blocks) - s.blockNum,
+		nBlocks:    s.blockNum,
+		norm:       s.blockNorm,
+	})
+	s.blockNum = 0
 }
 
 // drain ports spectrogram.c:536-566.
-func (a *analyzer) drain() {
-	if a.truncated {
+func (s *scheduler) drain() {
+	if s.truncated {
 		return
 	}
-	isamp := (a.dftSize - a.stepSize) / 2
-	leftOver := (isamp + a.read) % a.stepSize
-	if leftOver >= a.stepSize>>1 {
-		isamp += a.stepSize - leftOver
+	isamp := (s.dftSize - s.stepSize) / 2
+	leftOver := (isamp + s.read) % s.stepSize
+	if leftOver >= s.stepSize>>1 {
+		isamp += s.stepSize - leftOver
 	}
-	a.end = 0
-	a.endMin = -a.dftSize
-	a.flow(make([]float32, isamp))
-	if !a.truncated && a.blockNum != 0 {
-		a.blockNorm *= float64(a.blockSteps) / float64(a.blockNum)
-		a.doColumn()
+	s.end = 0
+	s.endMin = -s.dftSize
+	s.flow(isamp)
+	if !s.truncated && s.blockNum != 0 {
+		s.blockNorm *= float64(s.blockSteps) / float64(s.blockNum)
+		s.doColumn()
+	}
+}
+
+// columnRenderer is one goroutine's worth of DSP state: a transform plan, a
+// window it reshapes as `end` changes, and the scratch for one column.
+type columnRenderer struct {
+	a    *analysis
+	plan *fft.Plan
+	ws   *windowState
+
+	buf []float64 // sliding frame, len dftSize
+	mag []float64 // per-column power accumulator, len rows
+	pow []float64 // per-block power scratch, len rows; nil when a column is one DFT
+	db  []float64 // per-column dB scratch, len rows
+
+	frameStart int
+	lastEnd    int
+	primed     bool // frameStart and lastEnd are meaningful
+
+	max float64
+}
+
+func (a *analysis) newRenderer(plan *fft.Plan) *columnRenderer {
+	o := a.opts
+	r := &columnRenderer{
+		a:    a,
+		plan: plan,
+		ws:   newWindowState(o.dftSize, o.window),
+		buf:  make([]float64, o.dftSize),
+		mag:  make([]float64, o.rows),
+		db:   make([]float64, o.rows),
+		max:  -float64(o.dBRange), // spectrogram.c:443
+	}
+	// Only a column spanning several DFTs needs somewhere to accumulate from;
+	// a single-DFT column transforms straight into mag.
+	if o.blockSteps != 1 {
+		r.pow = make([]float64, o.rows)
+	}
+	return r
+}
+
+// run computes columns [from, to) into the analysis output.
+func (r *columnRenderer) run(samples []float32, blocks []blockPlan, columns []columnPlan, from, to int) {
+	for c := from; c < to; c++ {
+		cp := columns[c]
+		for i := range cp.nBlocks {
+			b := blocks[cp.firstBlock+i]
+			r.loadFrame(samples, b.start)
+			if !r.primed || b.end != r.lastEnd {
+				makeWindow(r.ws, b.end)
+				r.lastEnd = b.end
+			}
+			r.primed = true
+			// The first block of a column overwrites the accumulator instead of
+			// clearing it and adding, which is the whole of the work at the
+			// common one-DFT-per-column geometry. Summing one term is that term.
+			if i == 0 {
+				r.plan.PowerInto(r.mag, r.buf, r.ws.window)
+			} else {
+				r.plan.PowerInto(r.pow, r.buf, r.ws.window)
+				f64.Add(r.mag, r.mag, r.pow)
+			}
+		}
+		r.emit(c, cp.norm)
+	}
+}
+
+// loadFrame fills buf with the dftSize samples of the padded stream starting at
+// start. Successive frames advance by exactly stepSize, so the common case
+// slides the buffer and reads only the new tail; a worker pays the full read
+// once, for the first column of its range.
+func (r *columnRenderer) loadFrame(samples []float32, start int) {
+	dft, step := r.a.opts.dftSize, r.a.opts.stepSize
+	if r.primed && start == r.frameStart+step {
+		copy(r.buf[:dft-step], r.buf[step:dft])
+		fillFrom(r.buf[dft-step:], samples, start+dft-step)
+	} else {
+		fillFrom(r.buf, samples, start)
+	}
+	r.frameStart = start
+}
+
+// fillFrom writes the padded stream over [from, from+len(dst)) into dst as
+// float64. Positions before the first sample or after the last read as zero.
+func fillFrom(dst []float64, samples []float32, from int) {
+	lo, hi := 0, len(dst)
+	if from < 0 {
+		lo = min(-from, hi)
+	}
+	if e := len(samples) - from; e < hi {
+		hi = max(e, lo)
+	}
+	clear(dst[:lo])
+	clear(dst[hi:])
+	// The drain's last frames sit wholly inside the trailing pad, so there is no
+	// overlap with the input at all. Returning here is not just an optimisation:
+	// `from` is past the end of samples in that case, and even a zero-length
+	// slice taken at an out-of-range index panics.
+	if lo >= hi {
+		return
+	}
+	// Sliced to equal lengths so the store is provably in range; this loop sees
+	// every sample of the clip once per overlap factor.
+	src := samples[from+lo : from+hi]
+	d := dst[lo:hi]
+	for i, v := range src {
+		d[i] = float64(v)
+	}
+}
+
+// emit converts the accumulated power for column c into the analysis output.
+func (r *columnRenderer) emit(c int, norm float64) {
+	o := r.a.opts
+	// dBfs = 10*log10(mag*norm), vectorized over the whole column: a per-cell
+	// math.Log10 would be over half a million calls for a default-sized image.
+	//
+	// norm is exactly 1 whenever a column is one DFT, and x*1.0 == x for every
+	// float64, so that scaling pass is skipped rather than run as a copy.
+	src := r.mag
+	if norm != 1 {
+		f64.Scale(r.db, r.mag, norm)
+		src = r.db
+	}
+	f64.Log10(r.db, src)
+	// The factor of 10 rides along in the per-cell loops below rather than in a
+	// pass of its own: multiplication commutes exactly, so 10*db[i] is the same
+	// float64 that scaling the whole column would have produced, and the column
+	// is read once instead of twice.
+	gain := float64(o.gain)
+	db := r.db[:o.rows]
+	base := c * o.rows
+	if o.normalize {
+		dst := r.a.dBfs[base : base+o.rows]
+		for i, v := range db {
+			dBfs := 10*v + gain
+			dst[i] = float32(dBfs)
+			if d := 10 * v; d > r.max {
+				r.max = d
+			}
+		}
+		return
+	}
+	dst := r.a.idx[base : base+o.rows]
+	dbRange := float64(o.dBRange)
+	for i, v := range db {
+		// The round trip through float32 is deliberate, not an accident of the
+		// buffer type: the -n path stores float32 and quantises from that, so
+		// dropping the precision here too is what keeps the two paths producing
+		// the same image, and SoX's own float cache is what set the behaviour.
+		dst[i] = uint8(colourIndexAt(float64(float32(10*v+gain)), o.spectrumPoints, dbRange))
+	}
+}
+
+// quantise resolves the stored dBFS values to palette indices, which the -n
+// normalize path can only do once the whole image has been seen and autogain
+// is known. It leaves idx in the same column-major layout the default path
+// produces, so the raster pass in Render has a single form to handle.
+func (a *analysis) quantise(autogain float64) {
+	n := a.cols * a.opts.rows
+	a.idx = make([]uint8, n)
+	dbRange := float64(a.opts.dBRange)
+	src := a.dBfs[:n]
+	dst := a.idx[:n]
+	for i, dBfs := range src {
+		dst[i] = uint8(colourIndexAt(float64(dBfs)+autogain, a.opts.spectrumPoints, dbRange))
 	}
 }

--- a/sox/analyzer_test.go
+++ b/sox/analyzer_test.go
@@ -18,15 +18,24 @@ func TestAnalyzerToneConcentratesEnergy(t *testing.T) {
 	opt := normalize(Options{})
 	dft, rows := deriveDFTSize(opt)
 	xSize, pps := resolveTimeAxis(opt, dur)
-	ws := newWindowState(dft, opt.Window)
-	actual := makeWindow(ws, 0)
+	actual := makeWindow(newWindowState(dft, opt.Window), 0)
 	step, blocks, norm := stepSizing(actual, dft, rate, pps, opt.SlackOverlap)
 
-	a, err := newAnalyzer(dft, rows, step, blocks, norm, -opt.Gain, opt.DBRange, ws, xSize)
+	a, err := analyze(analyzerOpts{
+		dftSize: dft, rows: rows,
+		stepSize: step, blockSteps: blocks, blockNorm: norm,
+		gain: -opt.Gain, dBRange: opt.DBRange,
+		spectrumPoints: spectrumPoints(opt),
+		xSize:          xSize,
+		// The dBFS values are what this asserts on, so ask for the raw form.
+		normalize: true,
+		window:    opt.Window,
+		workers:   1,
+	}, sig)
 	if err != nil {
 		t.Fatal(err)
 	}
-	cols := a.run(sig)
+	cols := a.cols
 	if cols == 0 {
 		t.Fatal("no columns produced")
 	}
@@ -50,14 +59,22 @@ func TestAnalyzerColumnCountMatchesGeometry(t *testing.T) {
 	opt := normalize(Options{})
 	dft, rows := deriveDFTSize(opt)
 	xSize, pps := resolveTimeAxis(opt, dur)
-	ws := newWindowState(dft, opt.Window)
-	actual := makeWindow(ws, 0)
+	actual := makeWindow(newWindowState(dft, opt.Window), 0)
 	step, blocks, norm := stepSizing(actual, dft, rate, pps, opt.SlackOverlap)
-	a, err := newAnalyzer(dft, rows, step, blocks, norm, -opt.Gain, opt.DBRange, ws, xSize)
+	a, err := analyze(analyzerOpts{
+		dftSize: dft, rows: rows,
+		stepSize: step, blockSteps: blocks, blockNorm: norm,
+		gain: -opt.Gain, dBRange: opt.DBRange,
+		spectrumPoints: spectrumPoints(opt),
+		xSize:          xSize,
+		normalize:      true,
+		window:         opt.Window,
+		workers:        1,
+	}, sig)
 	if err != nil {
 		t.Fatal(err)
 	}
-	cols := a.run(sig)
+	cols := a.cols
 	// Expected columns ~ rate*dur / (step*blocks); never exceeds xSize.
 	exp := int(rate * dur / float64(step*blocks))
 	if cols > xSize {
@@ -68,17 +85,21 @@ func TestAnalyzerColumnCountMatchesGeometry(t *testing.T) {
 	}
 }
 
-// TestNewAnalyzerRejectsBinMismatch guards the invariant that rows equals the
-// DFT bin count. rows sizes every per-column buffer, and the simd reductions in
-// doColumn process only min(len(dst), len(src)) elements, so a mismatch would
+// TestAnalyzeRejectsBinMismatch guards the invariant that rows equals the DFT
+// bin count. rows sizes every per-column buffer, and the simd reductions in
+// emit process only min(len(dst), len(src)) elements, so a mismatch would
 // quietly truncate each column rather than fail.
-func TestNewAnalyzerRejectsBinMismatch(t *testing.T) {
-	ws := newWindowState(1024, WindowHann)
-	makeWindow(ws, 0)
-	if _, err := newAnalyzer(1024, 512, 256, 1, 1, 0, 120, ws, 100); err == nil {
+func TestAnalyzeRejectsBinMismatch(t *testing.T) {
+	base := analyzerOpts{
+		dftSize: 1024, stepSize: 256, blockSteps: 1, blockNorm: 1,
+		dBRange: 120, spectrumPoints: 251, xSize: 100, workers: 1,
+	}
+	bad, good := base, base
+	bad.rows, good.rows = 512, 513
+	if _, err := analyze(bad, nil); err == nil {
 		t.Fatal("expected an error when rows != dftSize/2+1, got nil")
 	}
-	if _, err := newAnalyzer(1024, 513, 256, 1, 1, 0, 120, ws, 100); err != nil {
+	if _, err := analyze(good, nil); err != nil {
 		t.Fatalf("expected the correct bin count to be accepted, got %v", err)
 	}
 }

--- a/sox/options.go
+++ b/sox/options.go
@@ -7,6 +7,7 @@ package sox
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/tphakala/go-spectrogram/internal/dsp"
 )
@@ -49,6 +50,18 @@ type Options struct {
 	LightBackground bool // SoX -l
 	Perm            int  // SoX -p, 1..6; 0 => 1
 	Quantisation    int  // SoX -q, 1..249; 0 => 249
+
+	// Workers caps the goroutines the analysis is spread over. It has no SoX
+	// equivalent: the columns of a spectrogram are independent once SoX's
+	// streaming state machine has said what each is made of, and the transform
+	// is most of the work, so rendering them in parallel is close to linear in
+	// cores. 0 means GOMAXPROCS, 1 renders on the calling goroutine. The image
+	// is identical either way; only latency changes.
+	//
+	// Set it to 1 when many spectrograms are already being rendered
+	// concurrently, where the default oversubscribes the machine and costs
+	// throughput to win latency that nobody is waiting on.
+	Workers int
 
 	Raw     bool   // SoX -r: render only the spectrogram raster, no axes/legend/text
 	Title   string // SoX -t: title centred at the top (adds 20 rows); "" means no title (sox -t "" is inexpressible)
@@ -131,6 +144,12 @@ func validate(o Options) error {
 	if o.Quantisation < 1 || o.Quantisation > 249 {
 		return fmt.Errorf("sox: Quantisation %d out of range 1..249", o.Quantisation)
 	}
+	// Rejected rather than clamped: 0 already means "pick for me", so silently
+	// treating a negative as 0 would make a typo or an arithmetic slip in the
+	// caller's worker count indistinguishable from asking for the default.
+	if o.Workers < 0 {
+		return fmt.Errorf("sox: Workers %d must not be negative (0 selects GOMAXPROCS)", o.Workers)
+	}
 	return nil
 }
 
@@ -139,4 +158,15 @@ func b2i(b bool) int {
 		return 1
 	}
 	return 0
+}
+
+// resolveWorkers maps Options.Workers onto a concrete goroutine count. The
+// callers cap it against the work available, so there is no size below which
+// this needs to opt out: even the smallest preset SoX consumers ask for is
+// nearly twice as fast on four cores.
+func resolveWorkers(want int) int {
+	if want > 0 {
+		return want
+	}
+	return runtime.GOMAXPROCS(0)
 }

--- a/sox/options_test.go
+++ b/sox/options_test.go
@@ -76,3 +76,25 @@ func TestNormalizeCommentDefault(t *testing.T) {
 		t.Errorf("Comment = %q, want %q", got, "hi")
 	}
 }
+
+// TestValidateRejectsNegativeWorkers pins that a negative worker count is an
+// error rather than a silent alias for the 0-selects-GOMAXPROCS default, which
+// is how a caller's arithmetic slip would otherwise disappear.
+func TestValidateRejectsNegativeWorkers(t *testing.T) {
+	if err := validate(normalize(Options{Workers: -1})); err == nil {
+		t.Fatal("expected an error for Workers -1, got nil")
+	}
+	for _, w := range []int{0, 1, 4} {
+		if err := validate(normalize(Options{Workers: w})); err != nil {
+			t.Errorf("Workers %d should be accepted, got %v", w, err)
+		}
+	}
+}
+
+// TestRenderRejectsNegativeWorkers checks the guard is reachable through the
+// public entry point, not just the internal validator.
+func TestRenderRejectsNegativeWorkers(t *testing.T) {
+	if _, err := Render(make([]float32, 8000), 8000, Options{Workers: -2}); err == nil {
+		t.Fatal("expected Render to reject a negative Workers, got nil")
+	}
+}

--- a/sox/palette.go
+++ b/sox/palette.go
@@ -27,22 +27,32 @@ func colourIndex(o Options, x float64) int {
 // times for the default size), where passing Options by value and recomputing
 // spectrumPoints per call is pure overhead: both are fixed for a whole image.
 func colourIndexAt(x float64, sp int, dbRange float64) int {
-	// NaN dBFS (e.g. from NaN input samples) compares false against every case
-	// below and would fall through to int(NaN), which is implementation-defined
-	// in Go. Map it to the floor colour instead.
-	if math.IsNaN(x) {
+	// Below the floor is kept as its own branch, not folded into the clamp
+	// below, because it is the one case that can skip the divide. Quiet content
+	// puts most of the image there (three quarters of the cells for a clean
+	// tone), the branch predicts near-perfectly either way, and a divide is the
+	// most expensive thing in this function.
+	if x < -dbRange {
 		return fixedPalette
 	}
-	var c int
-	switch {
-	case x < -dbRange:
+	// The remaining two SoX cases collapse into one expression plus a clamp.
+	// That is worth doing because this runs once per pixel and the boundary
+	// between them tracks the image content, so as a branch it is the
+	// unpredictable one: at or above 0 dBFS the expression is already at least
+	// sp-1, so clamping gives the same answer, exactly (x == 0 lands on sp-1).
+	//
+	// NaN dBFS (e.g. from NaN input samples) reaches here, since NaN compares
+	// false against the floor test, and would otherwise fall through to
+	// int(NaN), which is implementation-defined in Go. It fails the `> 0` test,
+	// so spelling the low clamp that way rather than as `< 0` maps it to the
+	// floor colour.
+	c := 1 + (1+x/dbRange)*float64(sp-2)
+	if !(c > 0) {
 		c = 0
-	case x >= 0:
-		c = sp - 1
-	default:
-		c = int(1 + (1+x/dbRange)*float64(sp-2))
+	} else if hi := float64(sp - 1); c > hi {
+		c = hi
 	}
-	return fixedPalette + c
+	return fixedPalette + int(c)
 }
 
 // makePalette ports spectrogram.c:583-663. Returns a palette of length exactly

--- a/sox/palette_test.go
+++ b/sox/palette_test.go
@@ -107,3 +107,47 @@ func requireSox(t *testing.T) {
 		t.Skip("sox binary not found; skipping oracle test")
 	}
 }
+
+// colourIndexRef is the original three-case form of colourIndexAt, kept as the
+// oracle for the branchless version that replaced it. The two must agree on
+// every input, including the boundaries and NaN.
+func colourIndexRef(x float64, sp int, dbRange float64) int {
+	if math.IsNaN(x) {
+		return fixedPalette
+	}
+	var c int
+	switch {
+	case x < -dbRange:
+		c = 0
+	case x >= 0:
+		c = sp - 1
+	default:
+		c = int(1 + (1+x/dbRange)*float64(sp-2))
+	}
+	return fixedPalette + c
+}
+
+func TestColourIndexAtMatchesReference(t *testing.T) {
+	for _, sp := range []int{3, 17, 169, 251} {
+		for _, dbRange := range []float64{20, 65, 120, 180} {
+			// Sweep well past both ends, with a step chosen not to divide the
+			// range evenly, so quantisation boundaries are hit off-grid as well
+			// as on it.
+			for x := -1.5 * dbRange; x <= 0.5*dbRange; x += dbRange / 997 {
+				if got, want := colourIndexAt(x, sp, dbRange), colourIndexRef(x, sp, dbRange); got != want {
+					t.Fatalf("colourIndexAt(%g, %d, %g) = %d, reference %d", x, sp, dbRange, got, want)
+				}
+			}
+			// The exact boundaries and the non-finite inputs, which the sweep
+			// above reaches only by luck.
+			for _, x := range []float64{
+				-dbRange, -dbRange - 1e-15, 0, -0.0, 1e-300, -1e-300,
+				math.NaN(), math.Inf(1), math.Inf(-1),
+			} {
+				if got, want := colourIndexAt(x, sp, dbRange), colourIndexRef(x, sp, dbRange); got != want {
+					t.Fatalf("colourIndexAt(%g, %d, %g) = %d, reference %d", x, sp, dbRange, got, want)
+				}
+			}
+		}
+	}
+}

--- a/sox/parallel_test.go
+++ b/sox/parallel_test.go
@@ -1,0 +1,110 @@
+package sox
+
+import (
+	"bytes"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// parallelCases covers the geometries whose scheduling differs: one DFT per
+// column and several, an image that fills its xSize and one that truncates, a
+// clip shorter than a single frame, and the -n path whose autogain is a
+// reduction across workers.
+func parallelCases() []struct {
+	name string
+	opt  Options
+	n    int
+	rate float64
+} {
+	return []struct {
+		name string
+		opt  Options
+		n    int
+		rate float64
+	}{
+		{"one-dft-per-column", Options{XSize: 1026, YSize: 513}, 15 * 24000, 24000},
+		{"many-dfts-per-column", Options{XSize: 258, YSize: 129}, 15 * 24000, 24000},
+		{"raw", Options{XSize: 514, YSize: 257, Raw: true}, 5 * 22050, 22050},
+		{"normalize", Options{XSize: 514, YSize: 257, Normalize: true}, 5 * 22050, 22050},
+		{"truncated", Options{XSize: 100, YSize: 129, PixelsPerSec: 500}, 3 * 16000, 16000},
+		{"short-clip", Options{XSize: 258, YSize: 513}, 700, 8000},
+		{"empty-clip", Options{XSize: 258, YSize: 129}, 0, 8000},
+		{"odd-length", Options{XSize: 300, YSize: 129}, 44101, 44100},
+		{"gain-and-range", Options{XSize: 258, YSize: 129, Gain: -20, DBRange: 65}, 4 * 8000, 8000},
+	}
+}
+
+func parallelSignal(n int) []float32 {
+	rng := rand.New(rand.NewSource(7))
+	s := make([]float32, n)
+	for i := range s {
+		t := float64(i) / 24000
+		// Tones over a noise floor: without the noise most cells land below the
+		// dB floor, which would hide any divergence in the quantisation.
+		s[i] = float32(0.4*math.Sin(2*math.Pi*997*t) +
+			0.1*math.Sin(2*math.Pi*4001*t) +
+			0.002*rng.NormFloat64())
+	}
+	return s
+}
+
+// TestParallelMatchesSequential is the invariant the whole schedule/execute
+// split exists to protect: how many goroutines the columns are spread over must
+// not be observable in the output. Worker counts that do not divide the column
+// count are included on purpose, since those are what put a column boundary
+// mid-window-reshape.
+func TestParallelMatchesSequential(t *testing.T) {
+	for _, tc := range parallelCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			sig := parallelSignal(tc.n)
+			seqOpt := tc.opt
+			seqOpt.Workers = 1
+			want, err := Render(sig, tc.rate, seqOpt)
+			if err != nil {
+				t.Fatalf("sequential render: %v", err)
+			}
+			for _, w := range []int{2, 3, 4, 5, 8, 17, 64, 4096} {
+				opt := tc.opt
+				opt.Workers = w
+				got, err := Render(sig, tc.rate, opt)
+				if err != nil {
+					t.Fatalf("workers=%d: %v", w, err)
+				}
+				if got.Bounds() != want.Bounds() {
+					t.Fatalf("workers=%d: bounds %v, sequential %v", w, got.Bounds(), want.Bounds())
+				}
+				if !bytes.Equal(got.Pix, want.Pix) {
+					n := 0
+					for i := range got.Pix {
+						if got.Pix[i] != want.Pix[i] {
+							n++
+						}
+					}
+					t.Fatalf("workers=%d: %d of %d pixels differ from the sequential render",
+						w, n, len(want.Pix))
+				}
+			}
+		})
+	}
+}
+
+// TestWorkersDefaultMatchesExplicit pins that leaving Workers unset renders the
+// same image as any explicit setting, so the default is a latency choice only.
+func TestWorkersDefaultMatchesExplicit(t *testing.T) {
+	sig := parallelSignal(10 * 24000)
+	opt := Options{XSize: 514, YSize: 257}
+	want, err := Render(sig, 24000, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seq := opt
+	seq.Workers = 1
+	got, err := Render(sig, 24000, seq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got.Pix, want.Pix) {
+		t.Error("the default worker count renders a different image than Workers=1")
+	}
+}

--- a/sox/render_bench_test.go
+++ b/sox/render_bench_test.go
@@ -80,25 +80,24 @@ func BenchmarkAnalyzer(b *testing.B) {
 			dft, rows := deriveDFTSize(o)
 			duration := float64(len(sig)) / benchRate
 			xSize, pps := resolveTimeAxis(o, duration)
+			actual := makeWindow(newWindowState(dft, o.Window), 0)
+			step, blocks, norm := stepSizing(actual, dft, benchRate, pps, o.SlackOverlap)
+			opts := analyzerOpts{
+				dftSize: dft, rows: rows,
+				stepSize: step, blockSteps: blocks, blockNorm: norm,
+				gain: -o.Gain, dBRange: o.DBRange,
+				spectrumPoints: spectrumPoints(o),
+				xSize:          xSize,
+				normalize:      o.Normalize,
+				window:         o.Window,
+				workers:        1,
+			}
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
-				// a.run mutates ws.window through makeWindow, so the window
-				// state cannot be shared across iterations. Build it with the
-				// timer stopped: newAnalyzer also builds an fft.Plan, whose
-				// twiddle tables cost ~2*half Sincos calls, and timing that
-				// would measure plan construction rather than the DSP.
-				b.StopTimer()
-				ws := newWindowState(dft, o.Window)
-				actual := makeWindow(ws, 0)
-				step, blocks, norm := stepSizing(actual, dft, benchRate, pps, o.SlackOverlap)
-				a, err := newAnalyzer(dft, rows, step, blocks, norm, -o.Gain, o.DBRange, ws, xSize)
-				if err != nil {
+				if _, err := analyze(opts, sig); err != nil {
 					b.Fatal(err)
 				}
-				b.StartTimer()
-
-				a.run(sig)
 			}
 		})
 	}
@@ -125,6 +124,27 @@ func BenchmarkWritePNG(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				if err := WritePNG(out, sig, benchRate, opt); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkRenderSerial is BenchmarkRender pinned to one goroutine, so the
+// per-core cost can be tracked separately from what parallelism buys.
+func BenchmarkRenderSerial(b *testing.B) {
+	sig := benchSignal(benchSeconds*benchRate, benchRate)
+	for _, p := range benchPresets {
+		b.Run(p.name, func(b *testing.B) {
+			opt := Options{XSize: p.xSize, YSize: p.ySize, Workers: 1}
+			if _, err := Render(sig, benchRate, opt); err != nil {
+				b.Fatalf("render: %v", err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := Render(sig, benchRate, opt); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/sox/sox.go
+++ b/sox/sox.go
@@ -6,6 +6,7 @@ import (
 	"image/png"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 // Render computes the SoX-compatible spectrogram image for mono `samples` at
@@ -27,19 +28,31 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 	duration := float64(len(samples)) / sampleRate
 	xSize, pps := resolveTimeAxis(o, duration)
 
-	ws := newWindowState(dft, o.Window)
-	actual := makeWindow(ws, 0)
+	workers := resolveWorkers(o.Workers)
+	// The full-length window is only needed for its sum, which sizes the hop;
+	// each analysis goroutine reshapes its own copy from there.
+	actual := makeWindow(newWindowState(dft, o.Window), 0)
 	step, blocks, norm := stepSizing(actual, dft, sampleRate, pps, o.SlackOverlap)
 
-	a, err := newAnalyzer(dft, rows, step, blocks, norm, -o.Gain, o.DBRange, ws, xSize)
+	a, err := analyze(analyzerOpts{
+		dftSize: dft, rows: rows,
+		stepSize: step, blockSteps: blocks, blockNorm: norm,
+		gain: -o.Gain, dBRange: o.DBRange,
+		spectrumPoints: spectrumPoints(o),
+		xSize:          xSize,
+		normalize:      o.Normalize,
+		window:         o.Window,
+		workers:        workers,
+	}, samples)
 	if err != nil {
-		return nil, fmt.Errorf("sox: building the analyzer for DFT size %d: %w", dft, err)
+		return nil, fmt.Errorf("sox: analyzing at DFT size %d: %w", dft, err)
 	}
-	cols := a.run(samples)
+	cols := a.cols
 
 	autogain := 0.0
 	if o.Normalize {
 		autogain = -a.max
+		a.quantise(autogain)
 	}
 
 	colsTotal, rowsTotal := cols, rows
@@ -51,34 +64,11 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 
 	// Draw in SoX's bottom-up coordinates, then blit flipped.
 	cv := &canvas{pix: make([]uint8, colsTotal*rowsTotal), cols: colsTotal}
-	// Resolve the palette constants once: they are fixed for the whole raster,
-	// and this loop runs once per pixel.
-	sp, dbRange := spectrumPoints(o), float64(o.DBRange)
-	// dBfs is column-major but the canvas is row-major, so this is a transpose.
-	// Walking it naively streams one source column against a destination stride
-	// of colsTotal, which evicts the destination from cache once per column at
-	// larger sizes. Tiling keeps both sides of the transpose resident.
-	const tile = 64
-	for colBase := 0; colBase < cols; colBase += tile {
-		colEnd := min(colBase+tile, cols)
-		for rowBase := 0; rowBase < rows; rowBase += tile {
-			rowEnd := min(rowBase+tile, rows)
-			// row-then-col inside the tile so the destination is written
-			// sequentially; the strided source reads stay in L1 for a 64x64 tile.
-			for row := rowBase; row < rowEnd; row++ {
-				// Slice to exactly the tile's span so the WRITE is bounds-check
-				// free; ranging over it is what proves dst[i] in range. The
-				// strided source read still carries one check per pixel, which
-				// Go has no way to express away.
-				start := (rasterY+row)*colsTotal + rasterX + colBase
-				dst := cv.pix[start : start+colEnd-colBase]
-				for i := range dst {
-					v := float64(a.dBfs[(colBase+i)*rows+row]) + autogain
-					dst[i] = uint8(colourIndexAt(v, sp, dbRange))
-				}
-			}
-		}
-	}
+	rasterBlit{
+		dst: cv.pix, src: a.idx,
+		cols: cols, rows: rows,
+		rasterX: rasterX, rasterY: rasterY, colsTotal: colsTotal,
+	}.run(workers)
 	if !o.Raw {
 		drawChrome(cv, chromeParams{
 			rasterCols: cols,
@@ -166,4 +156,74 @@ func WritePNG(path string, samples []float32, sampleRate float64, opt Options) (
 	}
 	renamed = true
 	return nil
+}
+
+// rasterBlit transposes the analysis output, which is column-major, into the
+// canvas, which is row-major.
+type rasterBlit struct {
+	dst, src         []uint8
+	cols, rows       int
+	rasterX, rasterY int
+	colsTotal        int
+}
+
+// blitTile is the side of the transpose that is walked in tiles. Walking the
+// source naively streams one column against a destination stride of colsTotal,
+// which evicts the destination from cache once per column at larger sizes;
+// tiling keeps both sides resident.
+const blitTile = 64
+
+// run performs the transpose, spread over up to workers goroutines.
+//
+// The split is by column tile, so each worker writes a disjoint span of every
+// row it touches and the shared destination needs no synchronisation. It is
+// worth parallelising at all because the analysis on either side of it already
+// is: left serial, moving a couple of megabytes through a strided read is a
+// quarter of the wall time of a large render.
+func (b rasterBlit) run(workers int) {
+	tiles := (b.cols + blitTile - 1) / blitTile
+	workers = min(max(workers, 1), tiles)
+	if workers <= 1 {
+		b.tiles(0, tiles)
+		return
+	}
+	var wg sync.WaitGroup
+	per := (tiles + workers - 1) / workers
+	for w := range workers {
+		from, to := w*per, min((w+1)*per, tiles)
+		if from >= to {
+			break
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			b.tiles(from, to)
+		}()
+	}
+	wg.Wait()
+}
+
+// tiles transposes the column tiles in [fromTile, toTile).
+func (b rasterBlit) tiles(fromTile, toTile int) {
+	for t := fromTile; t < toTile; t++ {
+		colBase := t * blitTile
+		colEnd := min(colBase+blitTile, b.cols)
+		for rowBase := 0; rowBase < b.rows; rowBase += blitTile {
+			rowEnd := min(rowBase+blitTile, b.rows)
+			// row-then-col inside the tile so the destination is written
+			// sequentially; the strided source reads stay resident for a tile.
+			for row := rowBase; row < rowEnd; row++ {
+				// Slice to exactly the tile's span so the WRITE is bounds-check
+				// free; ranging over it is what proves dst[i] in range. The
+				// strided source read still carries one check per pixel, which
+				// Go has no way to express away.
+				start := (b.rasterY+row)*b.colsTotal + b.rasterX + colBase
+				dst := b.dst[start : start+colEnd-colBase]
+				col := b.src[colBase*b.rows+row:]
+				for i := range dst {
+					dst[i] = col[i*b.rows]
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
`WritePNG` is now 2.7-3.7x the SoX binary on amd64 and 2.4-3.1x on arm64. arm64 used to be roughly a wash with sox; it no longer is. Single-core rendering is about 1.8x faster than before, so this is not only parallelism, and peak allocation at the largest size drops 47%.

All figures measured against sox 14.4.2 on the same idle host in the same machine state, at a pinned CPU governor, best of 6.

| size | `Render` | `Render` 1 core | `WritePNG` | sox 14.4.2 |
|---|---|---|---|---|
| 258 x 129 | 0.8 ms | 2.1 ms | **1.9 ms** | 5.4 ms |
| 514 x 257 | 1.0 ms | 2.4 ms | **2.6 ms** | 7.0 ms |
| 1026 x 513 | 1.7 ms | 4.5 ms | **4.4 ms** | 12.9 ms |
| 2050 x 1025 | 5.6 ms | 15.7 ms | **12.3 ms** | 45.2 ms |

arm64, Raspberry Pi 5 at a pinned 2.4 GHz:

| size | `Render` | `Render` 1 core | `WritePNG` | sox 14.4.2 |
|---|---|---|---|---|
| 258 x 129 | 2.1 ms | 6.9 ms | **4.1 ms** | 10.3 ms |
| 514 x 257 | 2.6 ms | 8.4 ms | **6.1 ms** | 14.6 ms |
| 1026 x 513 | 5.3 ms | 16.9 ms | **11.5 ms** | 30.6 ms |
| 2050 x 1025 | 18.7 ms | 63.7 ms | **36.1 ms** | 112.6 ms |

## The transform

The leading butterfly is twiddle-free, so it is fused into the load instead of running as its own pass over the scratch. To make that possible the load became a gather through an inverse digit-reversal table, which also keeps every store sequential. Per-stage twiddle tables are resolved once at plan time into contiguous arrays, replacing three strided reads of one shared table per butterfly.

simd v1.6.0 landed `f64.ButterflyComplex` (tphakala/simd#192), so the large-span stages now go through it. The kernel takes one contiguous run of pairs, so a full stage costs `n/(2*span)` calls, and the call overhead is what decides where it pays. Measured per stage over n=1024, kernel against the equivalent scalar loop:

| span | calls | kernel | scalar | speedup |
|---|---|---|---|---|
| 4 | 128 | 1143 ns | 1519 ns | 1.3x |
| 16 | 32 | 389 ns | 1444 ns | 3.7x |
| 64 | 8 | 192 ns | 1366 ns | 7.1x |
| 512 | 1 | 140 ns | 1367 ns | 9.8x |

The work is identical in every row; the spread is call overhead. So the decomposition runs a scalar radix-4 butterfly below span 8 and the kernel above, since one radix-4 stage does the work of two radix-2 stages for well under twice the cost.

`f64.RealFFTUnpack` is deliberately not used. It is correct and vectorized and still measured 13% slower here (benchstat, p=0.000, +39% at nfft 256), because it writes the complex spectrum and squaring that into power costs two more passes over the bins than emitting power directly. What would actually help is filed as tphakala/simd#198.

## The analysis

Split into a schedule pass and an execute pass. The schedule walks SoX's streaming state machine and records only what each column is made of; the execute pass computes the columns over `GOMAXPROCS` goroutines by default. Deriving the schedule by running the original state machine, rather than re-deriving closed forms for its sliding buffer, window ramp, truncation rule and renormalised final column, is what keeps the parallel port from drifting from the original.

Two passes disappeared along the way. A column that is a single DFT is transformed straight into its accumulator instead of being accumulated and then cleared, and the palette quantisation moved into the analyser, so the raster pass became a byte transpose over a quarter of the bytes.

`Options.Workers` controls the fan-out: 0 selects `GOMAXPROCS`, 1 renders on the calling goroutine, and the image is identical either way. **Callers already rendering many spectrograms concurrently will want `Workers: 1`**, since the default oversubscribes in that case. That is the one behavioural change here for existing users.

## Parity

Unchanged, and that is the point. Every case is still 100.000% of pixels exact with worst delta 0 against the sox binary, chrome and raster alike, on both architectures and with `SIMD_DISABLE=all`. The pre-existing `DBRange` 180 exception (329 of 410400 pixels one palette index off) is unchanged.

Worth stating explicitly: the vectorized butterfly associates its arithmetic differently from the scalar loop it replaced, so it is not bit-identical to it, and the images still are.

## Testing

- `TestParallelMatchesSequential` asserts pixel-identical output across 8 worker counts and 9 geometries (one DFT per column and several, truncated, short clip, empty clip, ragged length, `-n` normalize, raw). Verified stable over 20 repeats under `-race` and across `GOMAXPROCS` 1/2/3/7/16.
- `TestColourIndexAtMatchesReference` keeps the previous palette implementation as a differential oracle over a dense sweep plus the boundaries, NaN and both infinities.
- `TestCloneMatchesOriginal` and `TestCloneIsRaceFree` cover `Plan.Clone`, which is what lets workers share the twiddle tables.
- The existing FFT suite already sweeps nfft from 4 to 4096 against a naive DFT and against simd's `STFTPlan`, which is what covers the changed decomposition at every size; the fuzz target still passes.
