### PR TITLE
perf(sox): reusable Renderer to stop reallocating per render

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ So 9-19% off `Render`, and 1-10% off `WritePNG`, where the unchanged PNG encode
 dominates. The larger effect is on allocation: at 1026 x 513 a `Render` costs
 2.13 MiB across 447 allocations, a reused `Renderer` 1785 B across 97 (1088 B
 across 11 with `Raw`, which has no chrome text to format). Over 2000 renders at
-that size, measured on the amd64 host above, the collector ran 3956 times
-against 434.
+that size the collector ran 1703 times against 2, measured as the NumGC delta
+around exactly 2000 renders.
 
 What is left is the chrome tick labels, which go through `fmt`, and one closure
 per worker per pass. Neither is what the reuse is about, and together they are

--- a/README.md
+++ b/README.md
@@ -121,16 +121,17 @@ ten runs:
 
 | size        | amd64 `Render` | reused | arm64 `Render` | reused |
 |-------------|----------------|--------|----------------|--------|
-| 258 x 129   | 779.7 us | **678.0 us** | 2.250 ms | **1.849 ms** |
-| 514 x 257   | 923.7 us | **761.6 us** | 2.813 ms | **2.281 ms** |
-| 1026 x 513  | 1.716 ms | **1.528 ms** | 5.698 ms | **4.552 ms** |
-| 2050 x 1025 | 5.802 ms | **5.238 ms** | 20.16 ms | **18.21 ms** |
+| 258 x 129   | 780.2 us | **681.4 us** | 2.223 ms | **1.856 ms** |
+| 514 x 257   | 919.1 us | **761.7 us** | 2.801 ms | **2.287 ms** |
+| 1026 x 513  | 1.697 ms | **1.517 ms** | 5.620 ms | **4.539 ms** |
+| 2050 x 1025 | 5.744 ms | **5.251 ms** | 19.70 ms | **17.75 ms** |
 
-So 10-20% off `Render`, and 3-11% off `WritePNG`, where the unchanged PNG encode
+So 9-19% off `Render`, and 1-10% off `WritePNG`, where the unchanged PNG encode
 dominates. The larger effect is on allocation: at 1026 x 513 a `Render` costs
-2.13 MiB across 448 allocations, a reused `Renderer` 1785 B across 97 (1088 B
+2.13 MiB across 447 allocations, a reused `Renderer` 1785 B across 97 (1088 B
 across 11 with `Raw`, which has no chrome text to format). Over 2000 renders at
-that size the collector ran 1415 times against 26.
+that size, measured on the amd64 host above, the collector ran 3956 times
+against 434.
 
 What is left is the chrome tick labels, which go through `fmt`, and one closure
 per worker per pass. Neither is what the reuse is about, and together they are

--- a/README.md
+++ b/README.md
@@ -103,6 +103,45 @@ directly. The latter is why `unravelPower` is still scalar: v1.6.0's
 because writing the complex spectrum and squaring it afterwards costs two more
 passes over the bins than emitting power in one.
 
+### `sox`: rendering many clips at one preset
+
+`Render` allocates every buffer it needs on each call. A consumer producing many
+images at one preset, which is the usual way this package is used, can hold a
+`Renderer` instead, which keeps them:
+
+```go
+r, err := sox.NewRenderer(sox.Options{XSize: 1026, YSize: 513})
+for _, clip := range clips {
+    if err := r.WritePNG(clip.out, clip.samples, clip.rate); err != nil { ... }
+}
+```
+
+Same clip and sizes as above, `Render` against a warmed `Renderer`, medians of
+ten runs:
+
+| size        | amd64 `Render` | reused | arm64 `Render` | reused |
+|-------------|----------------|--------|----------------|--------|
+| 258 x 129   | 779.7 us | **678.0 us** | 2.250 ms | **1.849 ms** |
+| 514 x 257   | 923.7 us | **761.6 us** | 2.813 ms | **2.281 ms** |
+| 1026 x 513  | 1.716 ms | **1.528 ms** | 5.698 ms | **4.552 ms** |
+| 2050 x 1025 | 5.802 ms | **5.238 ms** | 20.16 ms | **18.21 ms** |
+
+So 10-20% off `Render`, and 3-11% off `WritePNG`, where the unchanged PNG encode
+dominates. The larger effect is on allocation: at 1026 x 513 a `Render` costs
+2.13 MiB across 448 allocations, a reused `Renderer` 1785 B across 97 (1088 B
+across 11 with `Raw`, which has no chrome text to format). Over 2000 renders at
+that size the collector ran 1415 times against 26.
+
+What is left is the chrome tick labels, which go through `fmt`, and one closure
+per worker per pass. Neither is what the reuse is about, and together they are
+under half a percent of the render.
+
+The trade is that a `Renderer` is stateful. The image it returns aliases the
+buffer the next call reuses, so it has to be treated as invalid once `Render` is
+called again (`WritePNG` encodes before returning and never exposes this), and
+one `Renderer` belongs to one goroutine. `Render` itself is unchanged and stays
+safe for concurrent use.
+
 ### `mel`: realtime bat preprocessing
 
 - **8.9 ms** to compute the mel spectrogram for **1 second** of 384 kHz audio.
@@ -149,7 +188,10 @@ types over shared DSP primitives:
   `*image.Paletted` matching `sox <in> -n spectrogram`: full chrome (axes,
   tick labels, dBFS legend, title/comment, SoX's embedded bitmap font) by
   default, bare raster via `Raw: true` (`sox ... -r`). Mono input,
-  power-of-2 DFT, all SoX palette modes.
+  power-of-2 DFT, all SoX palette modes. `Render` and `WritePNG` allocate per
+  call and are safe for concurrent use; `NewRenderer` returns a stateful,
+  single-goroutine `Renderer` that reuses its buffers across clips at a fixed
+  `Options`.
 - `internal/fft/` - vendored real-input transform used by `sox`. The transform
   dominates the render, and neither alternative was fast enough: `internal/dsp`
   runs a full-size complex FFT over real input, and simd's `f64.STFTPlan`
@@ -172,6 +214,10 @@ import "github.com/tphakala/go-spectrogram/sox"
 err := sox.WritePNG("out.png", samples, 44100, sox.Options{})        // full SoX PNG
 img, err := sox.Render(samples, 44100, sox.Options{Raw: true})       // raster only
 img, err = sox.Render(samples, 44100, sox.Options{Title: "My clip"}) // with title
+
+// Many clips at one preset: reuse the buffers (see the reuse section above).
+r, err := sox.NewRenderer(sox.Options{XSize: 1026, YSize: 513})
+err = r.WritePNG("out.png", samples, 44100)
 ```
 
 ## Status / honesty (things to finish as this grows into a lib)

--- a/sox/analyzer.go
+++ b/sox/analyzer.go
@@ -69,6 +69,44 @@ type analysis struct {
 	max  float64
 }
 
+// analysisScratch is everything the analysis allocates that a Renderer can
+// hand back on the next call: the output buffers, the schedule, the transform
+// plan and the per-worker DSP state.
+//
+// The buffers are grow-only. Their sizes track the column count, which varies
+// with clip duration, so a Renderer fed one long clip and then many short ones
+// holds the long clip's footprint until it is dropped. That is the trade a
+// reuse API exists to make, and the alternative (shrinking, or sizing to
+// Options.XSize up front) either reintroduces the allocation or pessimises the
+// common fixed-preset case.
+type analysisScratch struct {
+	a       analysis
+	idx     []uint8
+	dBfs    []float32
+	blocks  []blockPlan
+	columns []columnPlan
+	crs     []*columnRenderer
+	plan    *fft.Plan
+}
+
+// growU8 returns a slice of exactly n bytes, reusing b's array when it already
+// has the capacity. The contents are not cleared: every caller here writes all
+// n bytes before reading any, and the one place that does not (the canvas,
+// which chrome only partly paints) clears explicitly.
+func growU8(b []uint8, n int) []uint8 {
+	if cap(b) < n {
+		return make([]uint8, n)
+	}
+	return b[:n]
+}
+
+func growF32(b []float32, n int) []float32 {
+	if cap(b) < n {
+		return make([]float32, n)
+	}
+	return b[:n]
+}
+
 // analyze renders every column of the spectrogram for samples.
 //
 // It runs in two phases. The first walks SoX's streaming state machine to
@@ -80,13 +118,19 @@ type analysis struct {
 // by running that state machine rather than by re-deriving closed forms for it,
 // which is how a parallel port drifts from the original. What comes out is a
 // plan whose columns are independent and can be computed in any order.
-func analyze(o analyzerOpts, samples []float32) (*analysis, error) {
-	// dftSize is a power of two by construction (validate() rejects YSize values
-	// that do not yield one), so this only fails on a programming error.
-	plan, err := fft.NewPlan(o.dftSize)
-	if err != nil {
-		return nil, err
+func analyze(o analyzerOpts, samples []float32, s *analysisScratch) (*analysis, error) {
+	if s.plan == nil {
+		// dftSize is a power of two by construction (validate() rejects YSize
+		// values that do not yield one), so this only fails on a programming
+		// error. It is built once per scratch: dftSize derives from Options
+		// alone, which a Renderer fixes for its lifetime.
+		plan, err := fft.NewPlan(o.dftSize)
+		if err != nil {
+			return nil, err
+		}
+		s.plan = plan
 	}
+	plan := s.plan
 	// deriveDFTSize always returns rows == dftSize/2+1, which is exactly the
 	// plan's bin count. Assert it anyway: rows sizes every per-column buffer
 	// here, and the simd reductions in finishColumn silently process only
@@ -97,23 +141,49 @@ func analyze(o analyzerOpts, samples []float32) (*analysis, error) {
 			o.rows, plan.NumBins(), o.dftSize)
 	}
 
-	blocks, columns := schedule(o, len(samples))
-	a := &analysis{opts: o, cols: len(columns), max: -float64(o.dBRange)}
+	// [:0] rather than fresh slices: schedule appends, so reusing them unsliced
+	// would append this clip's schedule after the previous one's.
+	s.blocks, s.columns = schedule(o, len(samples), s.blocks[:0], s.columns[:0])
+	blocks, columns := s.blocks, s.columns
+
+	// Assigning the whole struct is what resets it, max included: a maximum
+	// carried over from a louder clip would render this one dark under -n.
+	a := &s.a
+	*a = analysis{opts: o, cols: len(columns), max: -float64(o.dBRange)}
 	n := a.cols * o.rows
+	// idx is sized on both paths. The -n path fills it in quantise rather than
+	// in emit, but it is the same buffer and the same layout either way.
+	s.idx = growU8(s.idx, n)
+	a.idx = s.idx
 	if o.normalize {
-		a.dBfs = make([]float32, n)
-	} else {
-		a.idx = make([]uint8, n)
+		s.dBfs = growF32(s.dBfs, n)
+		a.dBfs = s.dBfs
 	}
 	if a.cols == 0 {
 		return a, nil
 	}
 
 	workers := min(max(o.workers, 1), a.cols)
+	// Grown to the largest worker count seen, never clamped down: a Renderer
+	// whose first clip was short enough to need one worker must still fan out
+	// on the next one.
+	for len(s.crs) < workers {
+		// The first worker takes the plan itself; the rest clone it, sharing its
+		// twiddle tables and allocating only their own scratch.
+		p := plan
+		if len(s.crs) > 0 {
+			p = plan.Clone()
+		}
+		s.crs = append(s.crs, newColumnRenderer(o, p))
+	}
+	rs := s.crs[:workers]
+	for _, r := range rs {
+		r.reset(a)
+	}
+
 	if workers == 1 {
-		r := a.newRenderer(plan)
-		r.run(samples, blocks, columns, 0, a.cols)
-		a.max = r.max
+		rs[0].run(samples, blocks, columns, 0, a.cols)
+		a.max = rs[0].max
 		return a, nil
 	}
 
@@ -121,22 +191,13 @@ func analyze(o analyzerOpts, samples []float32) (*analysis, error) {
 	// there is nothing for a work queue to balance. Ranges are contiguous
 	// because a renderer slides its frame buffer and reshapes its window only
 	// when `end` changes, both of which are only cheap along a run of columns.
-	rs := make([]*columnRenderer, workers)
 	per := (a.cols + workers - 1) / workers
 	var wg sync.WaitGroup
-	for w := range workers {
+	for w, r := range rs {
 		from, to := w*per, min((w+1)*per, a.cols)
 		if from >= to {
 			break
 		}
-		// The first worker takes the plan just built; the rest clone it, sharing
-		// its twiddle tables and allocating only their own scratch.
-		p := plan
-		if w > 0 {
-			p = plan.Clone()
-		}
-		r := a.newRenderer(p)
-		rs[w] = r
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -145,7 +206,7 @@ func analyze(o analyzerOpts, samples []float32) (*analysis, error) {
 	}
 	wg.Wait()
 	for _, r := range rs {
-		if r != nil && r.max > a.max {
+		if r.max > a.max {
 			a.max = r.max
 		}
 	}
@@ -171,11 +232,17 @@ type scheduler struct {
 	columns []columnPlan
 }
 
-func schedule(o analyzerOpts, nSamples int) (blocks []blockPlan, columns []columnPlan) {
+// schedule walks the state machine for nSamples, appending into blocks and
+// columns. They are passed in rather than allocated so a Renderer can hand back
+// the previous call's arrays; pass nil for a fresh schedule. The scheduler
+// itself is always a fresh value, which is what keeps its half-dozen scalar
+// state fields from needing an explicit reset.
+func schedule(o analyzerOpts, nSamples int, blocks []blockPlan, columns []columnPlan) ([]blockPlan, []columnPlan) {
 	s := &scheduler{
 		dftSize: o.dftSize, stepSize: o.stepSize,
 		blockSteps: o.blockSteps, xSize: o.xSize,
 		blockNorm: o.blockNorm,
+		blocks:    blocks, columns: columns,
 	}
 	s.end = o.dftSize                     // spectrogram.c:429
 	s.endMin = 0                          // zeroed in start
@@ -270,23 +337,46 @@ type columnRenderer struct {
 	max float64
 }
 
-func (a *analysis) newRenderer(plan *fft.Plan) *columnRenderer {
-	o := a.opts
-	r := &columnRenderer{
-		a:    a,
+// newColumnRenderer allocates the state whose size depends only on the DFT
+// geometry, which a Renderer fixes for its lifetime. Everything that varies per
+// image is set by reset, which the caller must run before the first use.
+func newColumnRenderer(o analyzerOpts, plan *fft.Plan) *columnRenderer {
+	return &columnRenderer{
 		plan: plan,
 		ws:   newWindowState(o.dftSize, o.window),
 		buf:  make([]float64, o.dftSize),
 		mag:  make([]float64, o.rows),
 		db:   make([]float64, o.rows),
-		max:  -float64(o.dBRange), // spectrogram.c:443
 	}
-	// Only a column spanning several DFTs needs somewhere to accumulate from;
-	// a single-DFT column transforms straight into mag.
-	if o.blockSteps != 1 {
+}
+
+// reset points a renderer at the image about to be computed and returns its
+// carried state to what a freshly built one has.
+//
+// Both fields matter, and both fail silently rather than loudly if missed.
+// Leaving primed set makes loadFrame believe the stream is continuous, so the
+// first frame of the new clip slides in over the previous clip's tail instead
+// of being read afresh, and it can skip the makeWindow call when the new `end`
+// happens to equal the stale one. max is the -n autogain reference, so a peak
+// left over from a louder clip renders this one dark.
+//
+// The remaining buffers need no clearing: loadFrame, PowerInto and Log10 each
+// overwrite the whole of the slice they write, and makeWindow rewrites the
+// window in full.
+func (r *columnRenderer) reset(a *analysis) {
+	o := a.opts
+	r.a = a
+	r.primed = false
+	r.frameStart = 0
+	r.lastEnd = 0
+	r.max = -float64(o.dBRange) // spectrogram.c:443
+	// Only a column spanning several DFTs needs somewhere to accumulate from; a
+	// single-DFT column transforms straight into mag. blockSteps depends on the
+	// clip's sample rate as well as on Options, so a renderer reused across
+	// rates can need the accumulator on a later call having not needed it here.
+	if o.blockSteps != 1 && r.pow == nil {
 		r.pow = make([]float64, o.rows)
 	}
-	return r
 }
 
 // run computes columns [from, to) into the analysis output.
@@ -407,7 +497,6 @@ func (r *columnRenderer) emit(c int, norm float64) {
 // produces, so the raster pass in Render has a single form to handle.
 func (a *analysis) quantise(autogain float64) {
 	n := a.cols * a.opts.rows
-	a.idx = make([]uint8, n)
 	dbRange := float64(a.opts.dBRange)
 	src := a.dBfs[:n]
 	dst := a.idx[:n]

--- a/sox/analyzer.go
+++ b/sox/analyzer.go
@@ -89,24 +89,6 @@ type analysisScratch struct {
 	plan    *fft.Plan
 }
 
-// growU8 returns a slice of exactly n bytes, reusing b's array when it already
-// has the capacity. The contents are not cleared: every caller here writes all
-// n bytes before reading any, and the one place that does not (the canvas,
-// which chrome only partly paints) clears explicitly.
-func growU8(b []uint8, n int) []uint8 {
-	if cap(b) < n {
-		return make([]uint8, n)
-	}
-	return b[:n]
-}
-
-func growF32(b []float32, n int) []float32 {
-	if cap(b) < n {
-		return make([]float32, n)
-	}
-	return b[:n]
-}
-
 // analyze renders every column of the spectrogram for samples.
 //
 // It runs in two phases. The first walks SoX's streaming state machine to
@@ -118,6 +100,13 @@ func growF32(b []float32, n int) []float32 {
 // by running that state machine rather than by re-deriving closed forms for it,
 // which is how a parallel port drifts from the original. What comes out is a
 // plan whose columns are independent and can be computed in any order.
+//
+// s carries the buffers, schedule, transform plan and per-worker state between
+// calls; pass a fresh &analysisScratch{} to allocate everything. One scratch is
+// only valid for one fixed set of analyzerOpts: dftSize and window are baked
+// into the plan and the per-worker window states, and analyze rejects a reuse
+// that changes either. The returned *analysis is owned by the scratch and its
+// idx/dBfs alias it, so it is invalidated by the next analyze on the same one.
 func analyze(o analyzerOpts, samples []float32, s *analysisScratch) (*analysis, error) {
 	if s.plan == nil {
 		// dftSize is a power of two by construction (validate() rejects YSize
@@ -135,10 +124,22 @@ func analyze(o analyzerOpts, samples []float32, s *analysisScratch) (*analysis, 
 	// plan's bin count. Assert it anyway: rows sizes every per-column buffer
 	// here, and the simd reductions in finishColumn silently process only
 	// min(len(dst), len(src)) elements, so a mismatch would quietly truncate
-	// each column rather than fail.
+	// each column rather than fail. On a reused scratch it does double duty, as
+	// the only thing standing between a cached plan and a different DFT size.
 	if o.rows != plan.NumBins() {
 		return nil, fmt.Errorf("sox: rows %d does not match DFT bin count %d for size %d",
 			o.rows, plan.NumBins(), o.dftSize)
+	}
+	// The window is the other thing a reused scratch bakes in: each worker's
+	// windowState is built once and reset never revisits it, so reusing a
+	// scratch under a different WindowType would render every later image with
+	// the first one's window. That is bit-inexact against SoX with nothing to
+	// show for it, which is the failure this package can least afford to make
+	// silent. A Renderer fixes Options for its lifetime so it cannot happen
+	// today; this is what keeps that true.
+	if len(s.crs) > 0 && s.crs[0].ws.winType != o.window {
+		return nil, fmt.Errorf("sox: analysis scratch built for window %d, reused with %d",
+			s.crs[0].ws.winType, o.window)
 	}
 
 	// [:0] rather than fresh slices: schedule appends, so reusing them unsliced
@@ -153,10 +154,10 @@ func analyze(o analyzerOpts, samples []float32, s *analysisScratch) (*analysis, 
 	n := a.cols * o.rows
 	// idx is sized on both paths. The -n path fills it in quantise rather than
 	// in emit, but it is the same buffer and the same layout either way.
-	s.idx = growU8(s.idx, n)
+	s.idx = grow(s.idx, n)
 	a.idx = s.idx
 	if o.normalize {
-		s.dBfs = growF32(s.dBfs, n)
+		s.dBfs = grow(s.dBfs, n)
 		a.dBfs = s.dBfs
 	}
 	if a.cols == 0 {
@@ -166,7 +167,11 @@ func analyze(o analyzerOpts, samples []float32, s *analysisScratch) (*analysis, 
 	workers := min(max(o.workers, 1), a.cols)
 	// Grown to the largest worker count seen, never clamped down: a Renderer
 	// whose first clip was short enough to need one worker must still fan out
-	// on the next one.
+	// on the next one. Sized in one step rather than letting append double from
+	// nil, which cost five allocations on every fresh scratch.
+	if cap(s.crs) < workers {
+		s.crs = append(make([]*columnRenderer, 0, workers), s.crs...)
+	}
 	for len(s.crs) < workers {
 		// The first worker takes the plan itself; the rest clone it, sharing its
 		// twiddle tables and allocating only their own scratch.
@@ -353,12 +358,18 @@ func newColumnRenderer(o analyzerOpts, plan *fft.Plan) *columnRenderer {
 // reset points a renderer at the image about to be computed and returns its
 // carried state to what a freshly built one has.
 //
-// Both fields matter, and both fail silently rather than loudly if missed.
-// Leaving primed set makes loadFrame believe the stream is continuous, so the
-// first frame of the new clip slides in over the previous clip's tail instead
-// of being read afresh, and it can skip the makeWindow call when the new `end`
-// happens to equal the stale one. max is the -n autogain reference, so a peak
-// left over from a louder clip renders this one dark.
+// Of the five assignments only two carry meaning, and both fail silently rather
+// than loudly if missed. Leaving primed set makes loadFrame believe the stream
+// is continuous, so the first frame of the new clip slides in over the previous
+// clip's tail instead of being read afresh, and it can skip the makeWindow call
+// when the new `end` happens to equal the stale one. max is the -n autogain
+// reference, so a peak left over from a louder clip renders this one dark.
+//
+// frameStart, lastEnd and a are defensive: the first two are only read behind
+// primed, which is cleared just above them, and a is the same pointer for a
+// scratch's whole life. Mutation testing confirms all three are dead stores, so
+// resist writing a test for them; they are here to keep the reset obviously
+// complete rather than subtly sufficient.
 //
 // The remaining buffers need no clearing: loadFrame, PowerInto and Log10 each
 // overwrite the whole of the slice they write, and makeWindow rewrites the

--- a/sox/analyzer.go
+++ b/sox/analyzer.go
@@ -104,8 +104,9 @@ type analysisScratch struct {
 // s carries the buffers, schedule, transform plan and per-worker state between
 // calls; pass a fresh &analysisScratch{} to allocate everything. One scratch is
 // only valid for one fixed set of analyzerOpts: dftSize and window are baked
-// into the plan and the per-worker window states, and analyze rejects a reuse
-// that changes either. The returned *analysis is owned by the scratch and its
+// into the plan and the per-worker window states. analyze rejects a window
+// change directly, and catches a dftSize change indirectly, via the bin-count
+// check, because rows and dftSize always move together. The returned *analysis is owned by the scratch and its
 // idx/dBfs alias it, so it is invalidated by the next analyze on the same one.
 func analyze(o analyzerOpts, samples []float32, s *analysisScratch) (*analysis, error) {
 	if s.plan == nil {
@@ -365,11 +366,14 @@ func newColumnRenderer(o analyzerOpts, plan *fft.Plan) *columnRenderer {
 // when the new `end` happens to equal the stale one. max is the -n autogain
 // reference, so a peak left over from a louder clip renders this one dark.
 //
-// frameStart, lastEnd and a are defensive: the first two are only read behind
-// primed, which is cleared just above them, and a is the same pointer for a
-// scratch's whole life. Mutation testing confirms all three are dead stores, so
-// resist writing a test for them; they are here to keep the reset obviously
-// complete rather than subtly sufficient.
+// a is load-bearing and must not be removed: newColumnRenderer does not set it,
+// so the first reset of a newly appended renderer is what makes it non-nil, and
+// loadFrame dereferences it with no guard. It is only redundant on later resets.
+//
+// frameStart and lastEnd are the genuinely defensive pair: both are read only
+// behind primed, which is cleared just above them, so mutation testing shows
+// them surviving. They stay because they keep the reset obviously complete
+// rather than subtly sufficient, and cost two stores per image.
 //
 // The remaining buffers need no clearing: loadFrame, PowerInto and Log10 each
 // overwrite the whole of the slice they write, and makeWindow rewrites the

--- a/sox/analyzer_test.go
+++ b/sox/analyzer_test.go
@@ -31,7 +31,7 @@ func TestAnalyzerToneConcentratesEnergy(t *testing.T) {
 		normalize: true,
 		window:    opt.Window,
 		workers:   1,
-	}, sig)
+	}, sig, &analysisScratch{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestAnalyzerColumnCountMatchesGeometry(t *testing.T) {
 		normalize:      true,
 		window:         opt.Window,
 		workers:        1,
-	}, sig)
+	}, sig, &analysisScratch{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,10 +96,10 @@ func TestAnalyzeRejectsBinMismatch(t *testing.T) {
 	}
 	bad, good := base, base
 	bad.rows, good.rows = 512, 513
-	if _, err := analyze(bad, nil); err == nil {
+	if _, err := analyze(bad, nil, &analysisScratch{}); err == nil {
 		t.Fatal("expected an error when rows != dftSize/2+1, got nil")
 	}
-	if _, err := analyze(good, nil); err != nil {
+	if _, err := analyze(good, nil, &analysisScratch{}); err != nil {
 		t.Fatalf("expected the correct bin count to be accepted, got %v", err)
 	}
 }

--- a/sox/analyzer_test.go
+++ b/sox/analyzer_test.go
@@ -103,3 +103,35 @@ func TestAnalyzeRejectsBinMismatch(t *testing.T) {
 		t.Fatalf("expected the correct bin count to be accepted, got %v", err)
 	}
 }
+
+// TestAnalyzeRejectsWindowChangeOnReusedScratch covers the other thing a reused
+// scratch bakes in. Each worker's window state is built once and reset never
+// revisits it, so reusing a scratch under a different WindowType would render
+// every later image with the first one's window: no error, no panic, just a
+// spectrogram that is quietly wrong. A Renderer fixes Options for its lifetime
+// so it cannot happen through the exported API, which is exactly why the guard
+// needs a test of its own rather than incidental coverage.
+func TestAnalyzeRejectsWindowChangeOnReusedScratch(t *testing.T) {
+	o := analyzerOpts{
+		dftSize: 256, rows: 129, stepSize: 64, blockSteps: 1, blockNorm: 1,
+		dBRange: 120, spectrumPoints: 251, xSize: 100, workers: 1,
+		window: WindowHann,
+	}
+	samples := make([]float32, 4096)
+	s := &analysisScratch{}
+	if _, err := analyze(o, samples, s); err != nil {
+		t.Fatalf("first analyze: %v", err)
+	}
+
+	changed := o
+	changed.window = WindowHamming
+	if _, err := analyze(changed, samples, s); err == nil {
+		t.Fatal("expected an error reusing a scratch under a different window, got nil")
+	}
+	// The rejection must leave the scratch usable, not half-updated: an error
+	// return here is a programming-error guard, and poisoning the scratch would
+	// turn it into a second failure somewhere else.
+	if _, err := analyze(o, samples, s); err != nil {
+		t.Fatalf("original window rejected after the guard fired: %v", err)
+	}
+}

--- a/sox/options.go
+++ b/sox/options.go
@@ -3,6 +3,10 @@
 // By default it renders the full SoX PNG chrome (axes, tick labels, dBFS
 // legend, footer comment, optional title); Options.Raw gives the bare raster.
 // v1 is mono input, power-of-2 DFT.
+//
+// Render and WritePNG are the one-off entry points: they allocate per call and
+// are safe for concurrent use. To produce many images at one Options, see
+// NewRenderer, which keeps the buffers between clips.
 package sox
 
 import (

--- a/sox/render_bench_test.go
+++ b/sox/render_bench_test.go
@@ -95,7 +95,7 @@ func BenchmarkAnalyzer(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
-				if _, err := analyze(opts, sig); err != nil {
+				if _, err := analyze(opts, sig, &analysisScratch{}); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -124,6 +124,67 @@ func BenchmarkWritePNG(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				if err := WritePNG(out, sig, benchRate, opt); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkReusedRenderer is BenchmarkRender through a Renderer kept across
+// calls, which is how a consumer rendering many clips at one preset uses this
+// package. Compare it against BenchmarkRender at the same size: the difference
+// is what rebuilding the buffers and the transform plan costs per image.
+//
+// The Renderer is warmed before the timer starts, so what is measured is the
+// steady state rather than the first call, which still allocates everything.
+func BenchmarkReusedRenderer(b *testing.B) {
+	sig := benchSignal(benchSeconds*benchRate, benchRate)
+	for _, p := range benchPresets {
+		for _, raw := range []bool{false, true} {
+			name := p.name
+			if raw {
+				name += "_raw"
+			}
+			b.Run(name, func(b *testing.B) {
+				r, err := NewRenderer(Options{XSize: p.xSize, YSize: p.ySize, Raw: raw})
+				if err != nil {
+					b.Fatalf("new renderer: %v", err)
+				}
+				if _, err := r.Render(sig, benchRate); err != nil {
+					b.Fatalf("render: %v", err)
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					if _, err := r.Render(sig, benchRate); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkReusedRendererWritePNG is the batch-consumer path end to end, and
+// the one where reuse is unambiguously safe: the image never escapes.
+func BenchmarkReusedRendererWritePNG(b *testing.B) {
+	sig := benchSignal(benchSeconds*benchRate, benchRate)
+	dir := b.TempDir()
+	for _, p := range benchPresets {
+		b.Run(p.name, func(b *testing.B) {
+			r, err := NewRenderer(Options{XSize: p.xSize, YSize: p.ySize})
+			if err != nil {
+				b.Fatalf("new renderer: %v", err)
+			}
+			out := filepath.Join(dir, "reused_"+p.name+".png")
+			if err := r.WritePNG(out, sig, benchRate); err != nil {
+				b.Fatalf("write: %v", err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if err := r.WritePNG(out, sig, benchRate); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/sox/renderer.go
+++ b/sox/renderer.go
@@ -29,11 +29,11 @@ import (
 // one per worker goroutine, as with mel.Generator and fft.Plan. The free Render
 // stays safe for concurrent use.
 //
-// The buffers are grow-only, sized by the largest image rendered so far, so a
-// Renderer holds roughly two canvases plus the analysis output and the
-// per-worker state for its lifetime (a few megabytes at 1026x513, more with
-// Normalize, which adds a float32 buffer four times the size of the palette
-// indices). Drop the Renderer to release them.
+// The buffers are grow-only and grow geometrically, so a Renderer holds roughly
+// two canvases plus the analysis output and the per-worker state for its
+// lifetime, and up to twice that where a buffer last doubled (a few megabytes at
+// 1026x513, more with Normalize, which adds a float32 buffer four times the size
+// of the palette indices). Drop the Renderer to release them.
 type Renderer struct {
 	o    Options // normalized and validated
 	dft  int

--- a/sox/renderer.go
+++ b/sox/renderer.go
@@ -1,0 +1,229 @@
+package sox
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+)
+
+// Renderer renders repeatedly at one fixed Options, holding on to the buffers a
+// render needs instead of rebuilding them per call: the analysis output, the
+// schedule, the per-worker DSP state and transform plans, the canvas, and the
+// image's pixels. A consumer producing many images at a single preset, which is
+// the usual way this package is used, pays for those once rather than per image.
+// See the README for the measured figures.
+//
+// It is not the whole of a render's allocation. Chrome formats its tick labels
+// per image and the fan-out allocates a closure per worker, neither of which
+// this touches; the reuse is about the large buffers and the transform plan. Its
+// clearest effect is on the collector rather than on any one render, since those
+// buffers stop being garbage.
+//
+// It is strictly an optimisation: for any given clip it produces exactly the
+// image the free Render produces, and Render is implemented on top of it.
+//
+// Two things are traded for that. The returned image's pixels are reused, so a
+// caller must treat an image as invalid once it calls Render again; WritePNG
+// encodes before returning and so never exposes this. And a Renderer is
+// stateful, so it must not be used from more than one goroutine at a time: make
+// one per worker goroutine, as with mel.Generator and fft.Plan. The free Render
+// stays safe for concurrent use.
+//
+// The buffers are grow-only, sized by the largest image rendered so far, so a
+// Renderer holds roughly two canvases plus the analysis output and the
+// per-worker state for its lifetime (a few megabytes at 1026x513, more with
+// Normalize, which adds a float32 buffer four times the size of the palette
+// indices). Drop the Renderer to release them.
+type Renderer struct {
+	o    Options // normalized and validated
+	dft  int
+	rows int
+
+	// Fixed by Options, so computed once: the palette every returned image
+	// shares, the palette's spectrum length, and the raw sum of the full-length
+	// window, which is what sizes the hop. The worker count is deliberately not
+	// here; see Render.
+	pal            color.Palette
+	spectrumPoints int
+	windowSum      float64
+
+	scratch analysisScratch
+	cv      canvas
+	pix     []uint8
+}
+
+// NewRenderer validates opt and computes the state that depends on it alone. It
+// returns the same errors Render would for the same Options, just at
+// construction rather than on the first clip.
+//
+// The buffers themselves are allocated on first use, since their size depends on
+// the clip, so the first Render through a new Renderer costs what a free Render
+// costs and later ones do not.
+func NewRenderer(opt Options) (*Renderer, error) {
+	o := normalize(opt)
+	if err := validate(o); err != nil {
+		return nil, err
+	}
+	dft, rows := deriveDFTSize(o)
+	return &Renderer{
+		o: o, dft: dft, rows: rows,
+		pal:            makePalette(o),
+		spectrumPoints: spectrumPoints(o),
+		// The full-length window is only needed for its sum; each analysis
+		// goroutine reshapes its own copy from there.
+		windowSum: makeWindow(newWindowState(dft, o.Window), 0),
+	}, nil
+}
+
+// Render computes the spectrogram image for mono `samples` at `sampleRate`,
+// reusing the buffers from the previous call.
+//
+// The returned image aliases those buffers, so it must be treated as invalid
+// once Render is called again on this Renderer. Note that the invalidation is
+// not reliably observable: when the next clip needs a larger buffer the old
+// pixels survive untouched, so a caller that wrongly holds on to an image can
+// pass its own tests on one ordering of clips and produce corrupt output on
+// another. Copy the image, or use WritePNG.
+//
+// The header itself is fresh each call, so an image held from an earlier call
+// keeps its own Rect and Stride. Its Palette is shared by every image this
+// Renderer returns and must not be modified.
+func (r *Renderer) Render(samples []float32, sampleRate float64) (*image.Paletted, error) {
+	if err := checkSampleRate(sampleRate); err != nil {
+		return nil, err
+	}
+	o := r.o
+	duration := float64(len(samples)) / sampleRate
+	xSize, pps := resolveTimeAxis(o, duration)
+	step, blocks, norm := stepSizing(r.windowSum, r.dft, sampleRate, pps, o.SlackOverlap)
+
+	// Resolved per call rather than cached, so that a long-lived Renderer
+	// tracks GOMAXPROCS the way the free Render does. Go adjusts it at runtime
+	// from the cgroup CPU limit, so a container that is resized would otherwise
+	// leave this Renderer fanning out over a stale core count for its lifetime.
+	workers := resolveWorkers(o.Workers)
+
+	a, err := analyze(analyzerOpts{
+		dftSize: r.dft, rows: r.rows,
+		stepSize: step, blockSteps: blocks, blockNorm: norm,
+		gain: -o.Gain, dBRange: o.DBRange,
+		spectrumPoints: r.spectrumPoints,
+		xSize:          xSize,
+		normalize:      o.Normalize,
+		window:         o.Window,
+		workers:        workers,
+	}, samples, &r.scratch)
+	if err != nil {
+		return nil, fmt.Errorf("sox: analyzing at DFT size %d: %w", r.dft, err)
+	}
+	cols := a.cols
+
+	autogain := 0.0
+	if o.Normalize {
+		autogain = -a.max
+		a.quantise(autogain)
+	}
+
+	colsTotal, rowsTotal := cols, r.rows
+	rasterX, rasterY := 0, 0
+	if !o.Raw {
+		colsTotal, rowsTotal = chromeDims(cols, r.rows, o.Title)
+		rasterX, rasterY = left, below
+	}
+
+	// Draw in SoX's bottom-up coordinates, then blit flipped.
+	n := colsTotal * rowsTotal
+	var fresh bool
+	r.cv.pix, fresh = growFresh(r.cv.pix, n)
+	r.cv.cols = colsTotal
+	if !o.Raw && !fresh {
+		// Chrome paints only its text, ticks and border, and takes the rest of
+		// the canvas already being the background colour (palette index 0). On a
+		// reused buffer that has to be made true again, or the previous image's
+		// chrome ghosts through. A buffer grow just allocated is already zeroed,
+		// and with Raw the blit below covers every byte, so both of those skip
+		// the clear rather than merely not needing it.
+		clear(r.cv.pix)
+	}
+	rasterBlit{
+		dst: r.cv.pix, src: a.idx,
+		cols: cols, rows: r.rows,
+		rasterX: rasterX, rasterY: rasterY, colsTotal: colsTotal,
+	}.run(workers)
+	if !o.Raw {
+		drawChrome(&r.cv, chromeParams{
+			rasterCols: cols,
+			rasterRows: r.rows,
+			colsTotal:  colsTotal,
+			rowsTotal:  rowsTotal,
+			secs:       float64(cols) * float64(step) * float64(blocks) / sampleRate,
+			sampleRate: sampleRate,
+			autogain:   autogain,
+			o:          o,
+		})
+	}
+
+	r.pix = grow(r.pix, n)
+	img := &image.Paletted{
+		// Capped to its length, as image.NewPaletted's is: a grown buffer can
+		// carry spare capacity, and without the cap a caller's append would
+		// write into this Renderer's live pixels instead of a copy.
+		Pix:     r.pix[:n:n],
+		Stride:  colsTotal,
+		Rect:    image.Rect(0, 0, colsTotal, rowsTotal),
+		Palette: r.pal,
+	}
+	for y := 0; y < rowsTotal; y++ {
+		copy(img.Pix[y*img.Stride:y*img.Stride+colsTotal],
+			r.cv.pix[(rowsTotal-1-y)*colsTotal:(rowsTotal-y)*colsTotal])
+	}
+	return img, nil
+}
+
+// WritePNG renders and encodes to path exactly as the package-level WritePNG
+// does, reusing this Renderer's buffers. The image never escapes, so the
+// aliasing Render documents is invisible to the caller and this is the safest
+// way to use a Renderer.
+func (r *Renderer) WritePNG(path string, samples []float32, sampleRate float64) error {
+	img, err := r.Render(samples, sampleRate)
+	if err != nil {
+		return err
+	}
+	return encodePNG(path, img)
+}
+
+// checkSampleRate is shared by both entry points so that the message a caller
+// sees cannot come to depend on which one they used.
+func checkSampleRate(sampleRate float64) error {
+	if !(sampleRate > 0) { // also rejects NaN
+		return fmt.Errorf("sox: sampleRate must be positive, got %g", sampleRate)
+	}
+	return nil
+}
+
+// growFresh returns a slice of exactly n elements, reusing b's array when it is
+// already large enough, and reports whether it had to allocate.
+//
+// The contents are not cleared on reuse: every caller here writes all n elements
+// before reading any, and the one that does not (the canvas, which chrome only
+// partly paints) clears explicitly. The `fresh` result is what lets it skip even
+// that, since a slice make just returned is already zeroed.
+//
+// Growth is geometric rather than an exact fit. The buffers are sized by the
+// column count, which tracks clip duration when the caller drives the time axis
+// with PixelsPerSec, so growing tightly would reallocate on every clip slightly
+// longer than the last, which is the reuse this package exists to provide. A nil
+// slice always allocates, so that a zero-length result is non-nil, matching what
+// image.NewPaletted produced before.
+func growFresh[S ~[]E, E any](b S, n int) (S, bool) {
+	if b == nil || cap(b) < n {
+		return make(S, n, max(n, 2*cap(b))), true
+	}
+	return b[:n], false
+}
+
+// grow is growFresh for the callers that have nothing to clear.
+func grow[S ~[]E, E any](b S, n int) S {
+	s, _ := growFresh(b, n)
+	return s
+}

--- a/sox/renderer_test.go
+++ b/sox/renderer_test.go
@@ -2,6 +2,10 @@ package sox
 
 import (
 	"image"
+	// Registered explicitly rather than relying on sox.go importing it, so that
+	// image.Decode in assertDecodesTo does not depend on a non-test file's
+	// import set.
+	_ "image/png"
 	"math"
 	"os"
 	"path/filepath"
@@ -25,9 +29,10 @@ import (
 //   - normalize_multiblock is the only case whose dBFS buffer has to GROW on a
 //     reused Renderer. With an explicit XSize the column count is that size for
 //     every clip, so it can only shrink; driving the time axis with
-//     PixelsPerSec instead makes it track duration (51 columns for the 1 s clip,
-//     121 for the 12 s one). Without this case, a grow helper that never grew a
-//     live buffer passed the whole package.
+//     PixelsPerSec instead makes it track duration (measured over this corpus:
+//     50, 50, 120, 10, 30, 20, 1, 0 columns, so the 12 s clip grows it twice).
+//     Without this case, a grow helper that never grew a live buffer passed the
+//     whole package.
 //   - few_cols pins the partial fan-out, where some workers get an empty range.
 //     Reachability of that branch otherwise depends on the machine: it needs
 //     more than about six workers, and both CI runners have four.
@@ -228,13 +233,17 @@ func TestRendererReturnsFreshHeader(t *testing.T) {
 		t.Fatalf("render a: %v", err)
 	}
 	rectA := a.Rect
-	if cap(a.Pix) != len(a.Pix) {
-		t.Errorf("Pix cap %d exceeds len %d; append would write into the Renderer",
-			cap(a.Pix), len(a.Pix))
-	}
 	b, err := r.Render(clips[3].samples, clips[3].rate)
 	if err != nil {
 		t.Fatalf("render b: %v", err)
+	}
+	// Checked on the SECOND, smaller render, which is the only place it can
+	// fail: the first render allocates exactly n, so its capacity equals its
+	// length whether or not the returned slice is capped. Only after a shrink
+	// does the buffer carry spare capacity for an append to escape into.
+	if cap(b.Pix) != len(b.Pix) {
+		t.Errorf("Pix cap %d exceeds len %d; a caller's append would write into "+
+			"the Renderer's live pixels", cap(b.Pix), len(b.Pix))
 	}
 	if a == b {
 		t.Fatal("Render returned the same *image.Paletted header twice")
@@ -381,35 +390,45 @@ func TestRenderErrorPrecedence(t *testing.T) {
 }
 
 // TestRenderConcurrent pins the claim that the free Render stays safe for
-// concurrent use now that it is built on a stateful type. Run under -race this
-// is the whole assertion; the image comparison catches a shared buffer that
-// happens not to trip the detector.
+// concurrent use now that it is built on a stateful type.
+//
+// Each goroutine renders a DIFFERENT clip, which is what makes the image
+// comparison able to fail: if the entry points ever came to share a buffer,
+// eight goroutines all rendering the same clip would write identical bytes over
+// each other and compare equal, leaving -race as the only detector. With
+// distinct clips a shared buffer produces a visibly wrong image as well.
 func TestRenderConcurrent(t *testing.T) {
 	t.Parallel()
-	clip := reuseClips()[0]
 	opt := Options{XSize: 258, YSize: 129}
-	want, err := Render(clip.samples, clip.rate, opt)
-	if err != nil {
-		t.Fatalf("reference: %v", err)
+	clips := reuseClips()[:5] // the five that render a non-empty image
+	want := make([]*image.Paletted, len(clips))
+	for i, c := range clips {
+		img, err := Render(c.samples, c.rate, opt)
+		if err != nil {
+			t.Fatalf("reference %s: %v", c.name, err)
+		}
+		want[i] = img
 	}
 
-	const goroutines = 8
-	got := make([]*image.Paletted, goroutines)
-	errs := make([]error, goroutines)
+	const perClip = 3
+	n := len(clips) * perClip
+	got := make([]*image.Paletted, n)
+	errs := make([]error, n)
 	var wg sync.WaitGroup
-	for i := range goroutines {
+	for i := range n {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			got[i], errs[i] = Render(clip.samples, clip.rate, opt)
+			c := clips[i%len(clips)]
+			got[i], errs[i] = Render(c.samples, c.rate, opt)
 		}()
 	}
 	wg.Wait()
-	for i := range goroutines {
+	for i := range n {
 		if errs[i] != nil {
 			t.Fatalf("goroutine %d: %v", i, errs[i])
 		}
-		assertSameImage(t, "concurrent render", got[i], want)
+		assertSameImage(t, "concurrent "+clips[i%len(clips)].name, got[i], want[i%len(clips)])
 	}
 }
 

--- a/sox/renderer_test.go
+++ b/sox/renderer_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -16,6 +18,21 @@ import (
 // stale per-image maximum can bite, a title changes the canvas geometry, and
 // Workers: 1 takes the serial branch, which is a different reset path from the
 // fan-out one.
+//
+// The last three entries exist for properties the rest do not reach, each
+// verified rather than assumed:
+//
+//   - normalize_multiblock is the only case whose dBFS buffer has to GROW on a
+//     reused Renderer. With an explicit XSize the column count is that size for
+//     every clip, so it can only shrink; driving the time axis with
+//     PixelsPerSec instead makes it track duration (51 columns for the 1 s clip,
+//     121 for the 12 s one). Without this case, a grow helper that never grew a
+//     live buffer passed the whole package.
+//   - few_cols pins the partial fan-out, where some workers get an empty range.
+//     Reachability of that branch otherwise depends on the machine: it needs
+//     more than about six workers, and both CI runners have four.
+//   - multiblock keeps a case where a column spans several DFTs on a clip long
+//     enough to have many columns.
 var rendererCases = []struct {
 	name string
 	opt  Options
@@ -29,6 +46,8 @@ var rendererCases = []struct {
 	{"larger", Options{XSize: 514, YSize: 257}},
 	{"light_mono", Options{XSize: 258, YSize: 129, Monochrome: true, LightBackground: true}},
 	{"multiblock", Options{XSize: 258, YSize: 129, PixelsPerSec: 10}},
+	{"normalize_multiblock", Options{YSize: 129, PixelsPerSec: 10, Normalize: true}},
+	{"few_cols", Options{YSize: 129, PixelsPerSec: 10, Workers: 8}},
 }
 
 type reuseClip struct {
@@ -41,8 +60,16 @@ type reuseClip struct {
 // representative. Loud is followed by quiet because a maximum left over from a
 // previous render only changes the image when the next one is quieter, and the
 // lengths jump around because a stale frame position or an unsliced schedule
-// only shows up when the column count changes between calls. The last clip is
-// short enough to yield fewer columns than there are workers.
+// only shows up when the column count changes between calls.
+//
+// The tail is the awkward inputs: a clip whose samples are not finite, which is
+// what could drive the -n maximum somewhere pathological; one shorter than a
+// single DFT frame; and an empty one, which renders zero columns and is the
+// only input that reaches the early return in analyze. Note that "short" does
+// not by itself mean "few columns": with an explicit XSize, resolveTimeAxis
+// saturates pixels-per-second and the 29 ms clip still yields 175 columns. The
+// few-columns property belongs to the few_cols and multiblock Options entries,
+// not to any clip.
 func reuseClips() []reuseClip {
 	tone := func(n int, rate, amp float64) []float32 {
 		s := make([]float32, n)
@@ -52,19 +79,26 @@ func reuseClips() []reuseClip {
 		}
 		return s
 	}
+	nonFinite := tone(2*24000, 24000, 0.5)
+	nonFinite[100] = float32(math.NaN())
+	nonFinite[200] = float32(math.Inf(1))
+	nonFinite[300] = float32(math.Inf(-1))
+
 	return []reuseClip{
 		{"loud_5s", tone(5*24000, 24000, 0.9), 24000},
 		{"quiet_5s", tone(5*24000, 24000, 0.002), 24000},
 		{"long_12s", tone(12*24000, 24000, 0.5), 24000},
 		{"short_1s", tone(1*24000, 24000, 0.5), 24000},
 		{"other_rate_3s", tone(3*16000, 16000, 0.5), 16000},
+		{"non_finite_2s", nonFinite, 24000},
 		{"tiny", tone(700, 24000, 0.5), 24000},
+		{"empty", nil, 24000},
 	}
 }
 
-// assertSameImage compares two paletted images byte for byte. The palette is
-// compared too: it is cached on the Renderer, so a bug that shared one palette
-// across differing Options would only be visible here.
+// assertSameImage compares two paletted images byte for byte, including the
+// palette: a Renderer caches one and hands the same slice to every image it
+// returns, so a palette built from the wrong Options would only be visible here.
 func assertSameImage(t *testing.T, ctx string, got, want *image.Paletted) {
 	t.Helper()
 	if got.Rect != want.Rect {
@@ -105,10 +139,19 @@ func assertSameImage(t *testing.T, ctx string, got, want *image.Paletted) {
 // schedule appended to rather than reset, chrome ghosting through an uncleared
 // canvas) shows up as a wrong image and nothing else, so it is worth doing this
 // over the whole Options matrix rather than one representative case.
+//
+// Note what it can and cannot catch. Since Render is itself implemented as
+// NewRenderer(...).Render(...), both sides run the same single-render code, so
+// this is a differential between a virgin instance and a reused one: it pins
+// everything asymmetric about reuse and nothing about the render itself. The
+// independent oracle for the render is parity_test.go, which compares against
+// the SoX 14.4.2 binary bit for bit on two architectures.
 func TestRendererMatchesRender(t *testing.T) {
+	t.Parallel()
 	clips := reuseClips()
 	for _, tc := range rendererCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			r, err := NewRenderer(tc.opt)
 			if err != nil {
 				t.Fatalf("NewRenderer: %v", err)
@@ -133,9 +176,11 @@ func TestRendererMatchesRender(t *testing.T) {
 // same image both times; a buffer that is accumulated into rather than
 // overwritten would pass the sequence test above by luck but fail here.
 func TestRendererRepeatedIdenticalClip(t *testing.T) {
+	t.Parallel()
 	clip := reuseClips()[0]
 	for _, tc := range rendererCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			r, err := NewRenderer(tc.opt)
 			if err != nil {
 				t.Fatalf("NewRenderer: %v", err)
@@ -164,8 +209,12 @@ func TestRendererRepeatedIdenticalClip(t *testing.T) {
 // TestRendererReturnsFreshHeader documents the aliasing contract in the
 // direction that is safe to rely on: the returned *image.Paletted is a new
 // header every call, so holding on to an earlier one cannot make its Rect or
-// Stride change underneath the caller. Only the Pix bytes are reused.
+// Stride change underneath the caller. Only the pixels are reused.
+//
+// It also pins that the pixel slice is capped to its length, so a caller's
+// append allocates a copy instead of writing into the Renderer's live buffer.
 func TestRendererReturnsFreshHeader(t *testing.T) {
+	t.Parallel()
 	clips := reuseClips()
 	// Driven by PixelsPerSec, not XSize: with an explicit XSize the column count
 	// is that size whatever the clip's duration, so the image geometry would
@@ -179,6 +228,10 @@ func TestRendererReturnsFreshHeader(t *testing.T) {
 		t.Fatalf("render a: %v", err)
 	}
 	rectA := a.Rect
+	if cap(a.Pix) != len(a.Pix) {
+		t.Errorf("Pix cap %d exceeds len %d; append would write into the Renderer",
+			cap(a.Pix), len(a.Pix))
+	}
 	b, err := r.Render(clips[3].samples, clips[3].rate)
 	if err != nil {
 		t.Fatalf("render b: %v", err)
@@ -194,11 +247,17 @@ func TestRendererReturnsFreshHeader(t *testing.T) {
 	}
 }
 
-// bytesPerRender returns the bytes f allocates per call, averaged over n calls
-// after one warm-up. TotalAlloc is cumulative and unaffected by collection, so
-// this measures allocation rather than retained heap, which is the thing a
-// reuse API is meant to change.
-func bytesPerRender(n int, f func()) uint64 {
+// perRender returns the bytes and allocations f averages per call, over n calls
+// after one warm-up. TotalAlloc and Mallocs are cumulative counters unaffected
+// by collection, so this measures allocation rather than retained heap, which is
+// the thing a reuse API is meant to change.
+//
+// Both figures deliberately come from the same mechanism. testing.AllocsPerRun
+// would be the obvious way to count, but it pins GOMAXPROCS to 1 for its
+// duration, so a fresh Render measured through it fans out over one worker while
+// the Renderer being compared against was built for the ambient core count. That
+// is not a like-for-like comparison, and it reads as one.
+func perRender(n int, f func()) (bytes, allocs uint64) {
 	var before, after runtime.MemStats
 	f()
 	runtime.GC()
@@ -207,17 +266,20 @@ func bytesPerRender(n int, f func()) uint64 {
 		f()
 	}
 	runtime.ReadMemStats(&after)
-	return (after.TotalAlloc - before.TotalAlloc) / uint64(n)
+	return (after.TotalAlloc - before.TotalAlloc) / uint64(n),
+		(after.Mallocs - before.Mallocs) / uint64(n)
 }
 
 // TestRendererSteadyStateAllocs is the point of the whole change.
 //
-// It asserts on bytes rather than on allocation count, because bytes are what
-// the Renderer removes: the buffers it holds on to are three large ones, while
-// most of the remaining count is chrome formatting its tick labels and the
-// per-worker closures, neither of which this change touches. Both bounds are
-// loose on purpose, so that a later refactor moving a couple of allocations
-// does not fail a test whose subject is megabytes.
+// The bytes bound is the real assertion: the buffers are what the Renderer
+// holds, and they are three orders of magnitude larger than everything else.
+// The allocation count gets a much looser bound because most of what remains is
+// chrome formatting its tick labels and the per-worker closures, neither of
+// which this change touches. Both are ratios between two measurements taken the
+// same way in the same process, so neither depends on machine speed or load.
+//
+// Not run in parallel with anything: MemStats is process-wide.
 func TestRendererSteadyStateAllocs(t *testing.T) {
 	clip := reuseClips()[0]
 	opt := Options{XSize: 514, YSize: 257}
@@ -237,32 +299,46 @@ func TestRendererSteadyStateAllocs(t *testing.T) {
 		}
 	}
 
-	reusedBytes, freshBytes := bytesPerRender(20, render), bytesPerRender(20, free)
-	reusedAllocs := testing.AllocsPerRun(5, render)
-	freshAllocs := testing.AllocsPerRun(5, free)
-	t.Logf("per render: reused %d B / %.0f allocs, fresh %d B / %.0f allocs",
+	reusedBytes, reusedAllocs := perRender(20, render)
+	freshBytes, freshAllocs := perRender(20, free)
+	t.Logf("per render: reused %d B / %d allocs, fresh %d B / %d allocs",
 		reusedBytes, reusedAllocs, freshBytes, freshAllocs)
 
-	if reusedBytes*10 > freshBytes {
+	// 20x rather than 10x: a regression that stopped reusing only the schedule
+	// slices still came in at 12x, so the looser bound let it through.
+	if reusedBytes*20 > freshBytes {
 		t.Errorf("reused Renderer allocates %d B/render against %d B for a fresh Render; "+
-			"expected at least a 10x reduction", reusedBytes, freshBytes)
+			"expected at least a 20x reduction", reusedBytes, freshBytes)
 	}
 	if reusedAllocs*2 > freshAllocs {
-		t.Errorf("reused Renderer makes %.0f allocations/render against %.0f for a fresh Render; "+
+		t.Errorf("reused Renderer makes %d allocations/render against %d for a fresh Render; "+
 			"expected at least a 2x reduction", reusedAllocs, freshAllocs)
 	}
 }
 
-// TestRendererValidatesOptionsOnce checks that construction is where bad
-// Options are rejected, so a caller that builds a Renderer at startup learns
-// about a misconfiguration then rather than on the first clip.
-func TestRendererValidatesOptionsOnce(t *testing.T) {
-	if _, err := NewRenderer(Options{DBRange: 200}); err == nil {
-		t.Fatal("NewRenderer accepted DBRange 200")
+// TestRendererValidatesOptionsAtConstruction checks that bad Options are
+// rejected by the constructor, so a caller building a Renderer at startup learns
+// about a misconfiguration then rather than on the first clip, and that the
+// error is the same one Render would have given for the same Options.
+func TestRendererValidatesOptionsAtConstruction(t *testing.T) {
+	t.Parallel()
+	sig := reuseClips()[0].samples
+	for _, bad := range []Options{{DBRange: 200}, {XSize: 10}, {Workers: -1}} {
+		_, viaNew := NewRenderer(bad)
+		if viaNew == nil {
+			t.Errorf("NewRenderer accepted %+v", bad)
+			continue
+		}
+		_, viaRender := Render(sig, 24000, bad)
+		if viaRender == nil {
+			t.Errorf("Render accepted %+v", bad)
+			continue
+		}
+		if viaNew.Error() != viaRender.Error() {
+			t.Errorf("%+v: NewRenderer says %q, Render says %q", bad, viaNew, viaRender)
+		}
 	}
-	if _, err := NewRenderer(Options{XSize: 10}); err == nil {
-		t.Fatal("NewRenderer accepted XSize 10")
-	}
+
 	r, err := NewRenderer(Options{XSize: 258, YSize: 129})
 	if err != nil {
 		t.Fatalf("NewRenderer: %v", err)
@@ -274,24 +350,98 @@ func TestRendererValidatesOptionsOnce(t *testing.T) {
 	}
 }
 
+// TestRenderErrorPrecedence pins the ordering the free Render documents: a bad
+// sample rate is reported as such even when the Options are also invalid, so the
+// error a caller sees does not depend on which of their two mistakes is checked
+// first. NewRenderer deliberately orders it the other way, since it has no
+// sample rate to check.
+func TestRenderErrorPrecedence(t *testing.T) {
+	t.Parallel()
+	badOpts := Options{DBRange: 200}
+	err := func() error {
+		_, err := Render([]float32{0, 1, 0}, 0, badOpts)
+		return err
+	}()
+	if err == nil {
+		t.Fatal("Render accepted a zero sample rate with invalid Options")
+	}
+	if !strings.Contains(err.Error(), "sampleRate") {
+		t.Errorf("Render reported %q, want the sampleRate error to take precedence", err)
+	}
+	if err := WritePNG(filepath.Join(t.TempDir(), "x.png"), []float32{0, 1, 0}, 0, badOpts); err == nil {
+		t.Error("WritePNG accepted a zero sample rate")
+	} else if !strings.Contains(err.Error(), "sampleRate") {
+		t.Errorf("WritePNG reported %q, want the sampleRate error", err)
+	}
+	if _, err := NewRenderer(badOpts); err == nil {
+		t.Error("NewRenderer accepted DBRange 200")
+	} else if !strings.Contains(err.Error(), "DBRange") {
+		t.Errorf("NewRenderer reported %q, want the DBRange error", err)
+	}
+}
+
+// TestRenderConcurrent pins the claim that the free Render stays safe for
+// concurrent use now that it is built on a stateful type. Run under -race this
+// is the whole assertion; the image comparison catches a shared buffer that
+// happens not to trip the detector.
+func TestRenderConcurrent(t *testing.T) {
+	t.Parallel()
+	clip := reuseClips()[0]
+	opt := Options{XSize: 258, YSize: 129}
+	want, err := Render(clip.samples, clip.rate, opt)
+	if err != nil {
+		t.Fatalf("reference: %v", err)
+	}
+
+	const goroutines = 8
+	got := make([]*image.Paletted, goroutines)
+	errs := make([]error, goroutines)
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got[i], errs[i] = Render(clip.samples, clip.rate, opt)
+		}()
+	}
+	wg.Wait()
+	for i := range goroutines {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: %v", i, errs[i])
+		}
+		assertSameImage(t, "concurrent render", got[i], want)
+	}
+}
+
 // TestRendererWritePNG covers the path a batch consumer actually uses, where
-// the image never escapes and the aliasing is therefore invisible.
+// the image never escapes and the aliasing is therefore invisible. It runs the
+// whole clip corpus so that the geometry changes between writes, and decodes one
+// result so that a shared encoder regression cannot pass by producing two
+// identically wrong files.
 func TestRendererWritePNG(t *testing.T) {
+	t.Parallel()
 	opt := Options{XSize: 258, YSize: 129}
 	r, err := NewRenderer(opt)
 	if err != nil {
 		t.Fatalf("NewRenderer: %v", err)
 	}
 	dir := t.TempDir()
-	for i, c := range reuseClips()[:3] {
+	for i, c := range reuseClips() {
 		viaRenderer := filepath.Join(dir, "r"+string(rune('a'+i))+".png")
 		viaFunc := filepath.Join(dir, "f"+string(rune('a'+i))+".png")
-		if err := r.WritePNG(viaRenderer, c.samples, c.rate); err != nil {
-			t.Fatalf("%s: Renderer.WritePNG: %v", c.name, err)
+
+		errRenderer := r.WritePNG(viaRenderer, c.samples, c.rate)
+		errFunc := WritePNG(viaFunc, c.samples, c.rate, opt)
+		// The empty clip renders zero columns, which the PNG encoder rejects.
+		// Both entry points must agree on that, which is worth asserting rather
+		// than skipping.
+		if (errRenderer == nil) != (errFunc == nil) {
+			t.Fatalf("%s: Renderer.WritePNG err = %v, WritePNG err = %v", c.name, errRenderer, errFunc)
 		}
-		if err := WritePNG(viaFunc, c.samples, c.rate, opt); err != nil {
-			t.Fatalf("%s: WritePNG: %v", c.name, err)
+		if errFunc != nil {
+			continue
 		}
+
 		got, err := os.ReadFile(viaRenderer)
 		if err != nil {
 			t.Fatalf("read: %v", err)
@@ -302,6 +452,46 @@ func TestRendererWritePNG(t *testing.T) {
 		}
 		if string(got) != string(want) {
 			t.Errorf("%s: Renderer.WritePNG produced a different file from WritePNG", c.name)
+			continue
+		}
+		assertDecodesTo(t, c, viaRenderer, r)
+	}
+}
+
+// assertDecodesTo checks the written file really is the image the Renderer
+// produced, rather than two entry points agreeing on the same wrong bytes.
+func assertDecodesTo(t *testing.T, c reuseClip, path string, r *Renderer) {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("%s: open: %v", c.name, err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("%s: close: %v", c.name, err)
+		}
+	}()
+	decoded, _, err := image.Decode(f)
+	if err != nil {
+		t.Fatalf("%s: decode: %v", c.name, err)
+	}
+	pal, ok := decoded.(*image.Paletted)
+	if !ok {
+		t.Fatalf("%s: decoded to %T, want *image.Paletted", c.name, decoded)
+	}
+	fresh, err := r.Render(c.samples, c.rate)
+	if err != nil {
+		t.Fatalf("%s: re-render: %v", c.name, err)
+	}
+	if pal.Rect != fresh.Rect {
+		t.Fatalf("%s: decoded rect %v, want %v", c.name, pal.Rect, fresh.Rect)
+	}
+	for y := range fresh.Rect.Dy() {
+		for x := range fresh.Rect.Dx() {
+			if pal.ColorIndexAt(x, y) != fresh.ColorIndexAt(x, y) {
+				t.Fatalf("%s: decoded index at (%d,%d) = %d, want %d",
+					c.name, x, y, pal.ColorIndexAt(x, y), fresh.ColorIndexAt(x, y))
+			}
 		}
 	}
 }

--- a/sox/renderer_test.go
+++ b/sox/renderer_test.go
@@ -1,0 +1,307 @@
+package sox
+
+import (
+	"image"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// rendererCases is the Options matrix every reuse test runs over. Each entry
+// exercises a different piece of the state a Renderer carries between calls:
+// raw vs chrome decides whether the canvas has bytes no pass rewrites,
+// normalize decides which analysis buffer is used and is the only path where a
+// stale per-image maximum can bite, a title changes the canvas geometry, and
+// Workers: 1 takes the serial branch, which is a different reset path from the
+// fan-out one.
+var rendererCases = []struct {
+	name string
+	opt  Options
+}{
+	{"chrome", Options{XSize: 258, YSize: 129}},
+	{"raw", Options{XSize: 258, YSize: 129, Raw: true}},
+	{"normalize", Options{XSize: 258, YSize: 129, Normalize: true}},
+	{"normalize_raw", Options{XSize: 258, YSize: 129, Raw: true, Normalize: true}},
+	{"title", Options{XSize: 258, YSize: 129, Title: "reuse"}},
+	{"serial", Options{XSize: 258, YSize: 129, Workers: 1}},
+	{"larger", Options{XSize: 514, YSize: 257}},
+	{"light_mono", Options{XSize: 258, YSize: 129, Monochrome: true, LightBackground: true}},
+	{"multiblock", Options{XSize: 258, YSize: 129, PixelsPerSec: 10}},
+}
+
+type reuseClip struct {
+	name    string
+	samples []float32
+	rate    float64
+}
+
+// reuseClips is ordered to make stale state visible rather than to be
+// representative. Loud is followed by quiet because a maximum left over from a
+// previous render only changes the image when the next one is quieter, and the
+// lengths jump around because a stale frame position or an unsliced schedule
+// only shows up when the column count changes between calls. The last clip is
+// short enough to yield fewer columns than there are workers.
+func reuseClips() []reuseClip {
+	tone := func(n int, rate, amp float64) []float32 {
+		s := make([]float32, n)
+		for i := range s {
+			t := float64(i) / rate
+			s[i] = float32(amp * (math.Sin(2*math.Pi*1000*t) + 0.3*math.Sin(2*math.Pi*4300*t)))
+		}
+		return s
+	}
+	return []reuseClip{
+		{"loud_5s", tone(5*24000, 24000, 0.9), 24000},
+		{"quiet_5s", tone(5*24000, 24000, 0.002), 24000},
+		{"long_12s", tone(12*24000, 24000, 0.5), 24000},
+		{"short_1s", tone(1*24000, 24000, 0.5), 24000},
+		{"other_rate_3s", tone(3*16000, 16000, 0.5), 16000},
+		{"tiny", tone(700, 24000, 0.5), 24000},
+	}
+}
+
+// assertSameImage compares two paletted images byte for byte. The palette is
+// compared too: it is cached on the Renderer, so a bug that shared one palette
+// across differing Options would only be visible here.
+func assertSameImage(t *testing.T, ctx string, got, want *image.Paletted) {
+	t.Helper()
+	if got.Rect != want.Rect {
+		t.Fatalf("%s: rect = %v, want %v", ctx, got.Rect, want.Rect)
+	}
+	if got.Stride != want.Stride {
+		t.Fatalf("%s: stride = %d, want %d", ctx, got.Stride, want.Stride)
+	}
+	if len(got.Palette) != len(want.Palette) {
+		t.Fatalf("%s: palette len = %d, want %d", ctx, len(got.Palette), len(want.Palette))
+	}
+	for i := range want.Palette {
+		if got.Palette[i] != want.Palette[i] {
+			t.Fatalf("%s: palette[%d] = %v, want %v", ctx, i, got.Palette[i], want.Palette[i])
+		}
+	}
+	if len(got.Pix) != len(want.Pix) {
+		t.Fatalf("%s: pix len = %d, want %d", ctx, len(got.Pix), len(want.Pix))
+	}
+	for i := range want.Pix {
+		if got.Pix[i] != want.Pix[i] {
+			n := 0
+			for j := range want.Pix {
+				if got.Pix[j] != want.Pix[j] {
+					n++
+				}
+			}
+			t.Fatalf("%s: pix differs at %d (%d != %d), %d of %d bytes total",
+				ctx, i, got.Pix[i], want.Pix[i], n, len(want.Pix))
+		}
+	}
+}
+
+// TestRendererMatchesRender is the test that matters: a Renderer reused over a
+// sequence of different clips must produce exactly what a fresh Render produces
+// for each of them. Every stale-state bug the reuse introduces (a frame buffer
+// still primed from the previous clip, a maximum carried over under -n, a
+// schedule appended to rather than reset, chrome ghosting through an uncleared
+// canvas) shows up as a wrong image and nothing else, so it is worth doing this
+// over the whole Options matrix rather than one representative case.
+func TestRendererMatchesRender(t *testing.T) {
+	clips := reuseClips()
+	for _, tc := range rendererCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := NewRenderer(tc.opt)
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			for _, c := range clips {
+				want, err := Render(c.samples, c.rate, tc.opt)
+				if err != nil {
+					t.Fatalf("%s: Render: %v", c.name, err)
+				}
+				got, err := r.Render(c.samples, c.rate)
+				if err != nil {
+					t.Fatalf("%s: Renderer.Render: %v", c.name, err)
+				}
+				assertSameImage(t, c.name, got, want)
+			}
+		})
+	}
+}
+
+// TestRendererRepeatedIdenticalClip pins the simplest form of the same
+// property. Rendering one clip twice through the same Renderer must give the
+// same image both times; a buffer that is accumulated into rather than
+// overwritten would pass the sequence test above by luck but fail here.
+func TestRendererRepeatedIdenticalClip(t *testing.T) {
+	clip := reuseClips()[0]
+	for _, tc := range rendererCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := NewRenderer(tc.opt)
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			first, err := r.Render(clip.samples, clip.rate)
+			if err != nil {
+				t.Fatalf("first: %v", err)
+			}
+			// Copied because the next call overwrites the pixels in place, which
+			// is exactly the documented aliasing this test must not trip over.
+			snapshot := &image.Paletted{
+				Pix:     append([]uint8(nil), first.Pix...),
+				Stride:  first.Stride,
+				Rect:    first.Rect,
+				Palette: first.Palette,
+			}
+			second, err := r.Render(clip.samples, clip.rate)
+			if err != nil {
+				t.Fatalf("second: %v", err)
+			}
+			assertSameImage(t, "second render", second, snapshot)
+		})
+	}
+}
+
+// TestRendererReturnsFreshHeader documents the aliasing contract in the
+// direction that is safe to rely on: the returned *image.Paletted is a new
+// header every call, so holding on to an earlier one cannot make its Rect or
+// Stride change underneath the caller. Only the Pix bytes are reused.
+func TestRendererReturnsFreshHeader(t *testing.T) {
+	clips := reuseClips()
+	// Driven by PixelsPerSec, not XSize: with an explicit XSize the column count
+	// is that size whatever the clip's duration, so the image geometry would
+	// never change and the test would not be testing anything.
+	r, err := NewRenderer(Options{PixelsPerSec: 50, YSize: 129})
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	a, err := r.Render(clips[0].samples, clips[0].rate)
+	if err != nil {
+		t.Fatalf("render a: %v", err)
+	}
+	rectA := a.Rect
+	b, err := r.Render(clips[3].samples, clips[3].rate)
+	if err != nil {
+		t.Fatalf("render b: %v", err)
+	}
+	if a == b {
+		t.Fatal("Render returned the same *image.Paletted header twice")
+	}
+	if a.Rect != rectA {
+		t.Fatalf("earlier header mutated: rect = %v, want %v", a.Rect, rectA)
+	}
+	if b.Rect == rectA {
+		t.Fatal("test is not exercising a geometry change; both clips gave the same rect")
+	}
+}
+
+// bytesPerRender returns the bytes f allocates per call, averaged over n calls
+// after one warm-up. TotalAlloc is cumulative and unaffected by collection, so
+// this measures allocation rather than retained heap, which is the thing a
+// reuse API is meant to change.
+func bytesPerRender(n int, f func()) uint64 {
+	var before, after runtime.MemStats
+	f()
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	for range n {
+		f()
+	}
+	runtime.ReadMemStats(&after)
+	return (after.TotalAlloc - before.TotalAlloc) / uint64(n)
+}
+
+// TestRendererSteadyStateAllocs is the point of the whole change.
+//
+// It asserts on bytes rather than on allocation count, because bytes are what
+// the Renderer removes: the buffers it holds on to are three large ones, while
+// most of the remaining count is chrome formatting its tick labels and the
+// per-worker closures, neither of which this change touches. Both bounds are
+// loose on purpose, so that a later refactor moving a couple of allocations
+// does not fail a test whose subject is megabytes.
+func TestRendererSteadyStateAllocs(t *testing.T) {
+	clip := reuseClips()[0]
+	opt := Options{XSize: 514, YSize: 257}
+
+	r, err := NewRenderer(opt)
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	render := func() {
+		if _, err := r.Render(clip.samples, clip.rate); err != nil {
+			t.Fatalf("reused: %v", err)
+		}
+	}
+	free := func() {
+		if _, err := Render(clip.samples, clip.rate, opt); err != nil {
+			t.Fatalf("fresh: %v", err)
+		}
+	}
+
+	reusedBytes, freshBytes := bytesPerRender(20, render), bytesPerRender(20, free)
+	reusedAllocs := testing.AllocsPerRun(5, render)
+	freshAllocs := testing.AllocsPerRun(5, free)
+	t.Logf("per render: reused %d B / %.0f allocs, fresh %d B / %.0f allocs",
+		reusedBytes, reusedAllocs, freshBytes, freshAllocs)
+
+	if reusedBytes*10 > freshBytes {
+		t.Errorf("reused Renderer allocates %d B/render against %d B for a fresh Render; "+
+			"expected at least a 10x reduction", reusedBytes, freshBytes)
+	}
+	if reusedAllocs*2 > freshAllocs {
+		t.Errorf("reused Renderer makes %.0f allocations/render against %.0f for a fresh Render; "+
+			"expected at least a 2x reduction", reusedAllocs, freshAllocs)
+	}
+}
+
+// TestRendererValidatesOptionsOnce checks that construction is where bad
+// Options are rejected, so a caller that builds a Renderer at startup learns
+// about a misconfiguration then rather than on the first clip.
+func TestRendererValidatesOptionsOnce(t *testing.T) {
+	if _, err := NewRenderer(Options{DBRange: 200}); err == nil {
+		t.Fatal("NewRenderer accepted DBRange 200")
+	}
+	if _, err := NewRenderer(Options{XSize: 10}); err == nil {
+		t.Fatal("NewRenderer accepted XSize 10")
+	}
+	r, err := NewRenderer(Options{XSize: 258, YSize: 129})
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	for _, rate := range []float64{0, -1, math.NaN()} {
+		if _, err := r.Render([]float32{0, 1, 0}, rate); err == nil {
+			t.Errorf("Renderer.Render accepted sampleRate %g", rate)
+		}
+	}
+}
+
+// TestRendererWritePNG covers the path a batch consumer actually uses, where
+// the image never escapes and the aliasing is therefore invisible.
+func TestRendererWritePNG(t *testing.T) {
+	opt := Options{XSize: 258, YSize: 129}
+	r, err := NewRenderer(opt)
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	dir := t.TempDir()
+	for i, c := range reuseClips()[:3] {
+		viaRenderer := filepath.Join(dir, "r"+string(rune('a'+i))+".png")
+		viaFunc := filepath.Join(dir, "f"+string(rune('a'+i))+".png")
+		if err := r.WritePNG(viaRenderer, c.samples, c.rate); err != nil {
+			t.Fatalf("%s: Renderer.WritePNG: %v", c.name, err)
+		}
+		if err := WritePNG(viaFunc, c.samples, c.rate, opt); err != nil {
+			t.Fatalf("%s: WritePNG: %v", c.name, err)
+		}
+		got, err := os.ReadFile(viaRenderer)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		want, err := os.ReadFile(viaFunc)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("%s: Renderer.WritePNG produced a different file from WritePNG", c.name)
+		}
+	}
+}

--- a/sox/sox.go
+++ b/sox/sox.go
@@ -3,49 +3,99 @@ package sox
 import (
 	"fmt"
 	"image"
+	"image/color"
 	"image/png"
 	"os"
 	"path/filepath"
 	"sync"
 )
 
-// Render computes the SoX-compatible spectrogram image for mono `samples` at
-// `sampleRate`. By default it produces the full SoX PNG layout: raster plus
-// axes, tick labels, dBFS legend, footer comment, and optional title,
-// equivalent to `sox <in> -n spectrogram`. With opt.Raw it renders only the
-// raster (`sox ... spectrogram -r`), oriented like SoX: low frequency at the
-// bottom row, time left-to-right.
-func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted, error) {
-	if !(sampleRate > 0) { // also rejects NaN
-		return nil, fmt.Errorf("sox: sampleRate must be positive, got %g", sampleRate)
-	}
+// Renderer renders repeatedly at one fixed Options, holding on to every buffer
+// a render needs instead of rebuilding them per call. A consumer producing many
+// images at a single preset, which is the usual way this package is used, pays
+// the allocations once rather than about 2.7 MB across ~580 allocations per
+// image, along with the transform plan's ~1000 sincos calls.
+//
+// It is strictly an optimisation: for any given clip it produces exactly the
+// image the free Render produces, and Render is implemented on top of it.
+//
+// Two things are traded for that. The returned image's Pix array is reused, so
+// it is overwritten by the next call on the same Renderer; a caller that needs
+// to keep an image must copy it or use WritePNG, which encodes before returning.
+// And a Renderer is stateful, so it must not be used from more than one
+// goroutine at a time. Render itself stays safe for concurrent use, since it
+// builds its own. Callers wanting both reuse and concurrency should keep a
+// sync.Pool of Renderers, one in flight per goroutine.
+//
+// The buffers are grow-only, sized by the longest clip rendered so far. Drop
+// the Renderer to release them.
+type Renderer struct {
+	o    Options // normalized and validated
+	dft  int
+	rows int
+
+	// Fixed by Options, so computed once: the palette every returned image
+	// shares, the number of goroutines to fan out over, and the raw sum of the
+	// full-length window, which is what sizes the hop.
+	pal            color.Palette
+	workers        int
+	spectrumPoints int
+	windowSum      float64
+
+	scratch analysisScratch
+	cv      canvas
+	pix     []uint8
+}
+
+// NewRenderer validates opt once and prepares the buffers for it. It returns
+// the same errors Render would for the same Options, just at construction
+// rather than on the first clip.
+func NewRenderer(opt Options) (*Renderer, error) {
 	o := normalize(opt)
 	if err := validate(o); err != nil {
 		return nil, err
 	}
-
 	dft, rows := deriveDFTSize(o)
+	return &Renderer{
+		o: o, dft: dft, rows: rows,
+		pal:            makePalette(o),
+		workers:        resolveWorkers(o.Workers),
+		spectrumPoints: spectrumPoints(o),
+		// The full-length window is only needed for its sum; each analysis
+		// goroutine reshapes its own copy from there.
+		windowSum: makeWindow(newWindowState(dft, o.Window), 0),
+	}, nil
+}
+
+// Render computes the spectrogram image for mono `samples` at `sampleRate`,
+// reusing the buffers from the previous call.
+//
+// The returned image aliases those buffers: its Pix contents are overwritten by
+// the next Render on this Renderer. The header itself is fresh each call, so an
+// image held from an earlier call keeps its own Rect and Stride. Its Palette is
+// shared by every image this Renderer returns and must not be modified, which
+// is a fair reading of an image's palette in any case.
+func (r *Renderer) Render(samples []float32, sampleRate float64) (*image.Paletted, error) {
+	if !(sampleRate > 0) { // also rejects NaN
+		return nil, fmt.Errorf("sox: sampleRate must be positive, got %g", sampleRate)
+	}
+	o := r.o
 	duration := float64(len(samples)) / sampleRate
 	xSize, pps := resolveTimeAxis(o, duration)
-
-	workers := resolveWorkers(o.Workers)
-	// The full-length window is only needed for its sum, which sizes the hop;
-	// each analysis goroutine reshapes its own copy from there.
-	actual := makeWindow(newWindowState(dft, o.Window), 0)
-	step, blocks, norm := stepSizing(actual, dft, sampleRate, pps, o.SlackOverlap)
+	step, blocks, norm := stepSizing(r.windowSum, r.dft, sampleRate, pps, o.SlackOverlap)
 
 	a, err := analyze(analyzerOpts{
-		dftSize: dft, rows: rows,
+		dftSize: r.dft, rows: r.rows,
 		stepSize: step, blockSteps: blocks, blockNorm: norm,
 		gain: -o.Gain, dBRange: o.DBRange,
-		spectrumPoints: spectrumPoints(o),
+		spectrumPoints: r.spectrumPoints,
 		xSize:          xSize,
 		normalize:      o.Normalize,
 		window:         o.Window,
-		workers:        workers,
-	}, samples)
+		workers:        r.workers,
+	}, samples, &r.scratch)
 	if err != nil {
-		return nil, fmt.Errorf("sox: analyzing at DFT size %d: %w", dft, err)
+		return nil, fmt.Errorf("sox: analyzing at DFT size %d: %w", r.dft, err)
 	}
 	cols := a.cols
 
@@ -55,24 +105,33 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 		a.quantise(autogain)
 	}
 
-	colsTotal, rowsTotal := cols, rows
+	colsTotal, rowsTotal := cols, r.rows
 	rasterX, rasterY := 0, 0
 	if !o.Raw {
-		colsTotal, rowsTotal = chromeDims(cols, rows, o.Title)
+		colsTotal, rowsTotal = chromeDims(cols, r.rows, o.Title)
 		rasterX, rasterY = left, below
 	}
 
 	// Draw in SoX's bottom-up coordinates, then blit flipped.
-	cv := &canvas{pix: make([]uint8, colsTotal*rowsTotal), cols: colsTotal}
-	rasterBlit{
-		dst: cv.pix, src: a.idx,
-		cols: cols, rows: rows,
-		rasterX: rasterX, rasterY: rasterY, colsTotal: colsTotal,
-	}.run(workers)
+	n := colsTotal * rowsTotal
+	r.cv.pix, r.cv.cols = growU8(r.cv.pix, n), colsTotal
 	if !o.Raw {
-		drawChrome(cv, chromeParams{
+		// Chrome paints only its text, ticks and border, and takes the rest of
+		// the canvas already being the background colour (palette index 0). On a
+		// reused buffer that has to be made true again, or the previous image's
+		// chrome ghosts through. With Raw the blit below covers every byte, so
+		// the clear is skipped rather than merely being unnecessary.
+		clear(r.cv.pix)
+	}
+	rasterBlit{
+		dst: r.cv.pix, src: a.idx,
+		cols: cols, rows: r.rows,
+		rasterX: rasterX, rasterY: rasterY, colsTotal: colsTotal,
+	}.run(r.workers)
+	if !o.Raw {
+		drawChrome(&r.cv, chromeParams{
 			rasterCols: cols,
-			rasterRows: rows,
+			rasterRows: r.rows,
 			colsTotal:  colsTotal,
 			rowsTotal:  rowsTotal,
 			secs:       float64(cols) * float64(step) * float64(blocks) / sampleRate,
@@ -82,13 +141,42 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 		})
 	}
 
-	pal := makePalette(o)
-	img := image.NewPaletted(image.Rect(0, 0, colsTotal, rowsTotal), pal)
+	r.pix = growU8(r.pix, n)
+	img := &image.Paletted{
+		Pix:     r.pix,
+		Stride:  colsTotal,
+		Rect:    image.Rect(0, 0, colsTotal, rowsTotal),
+		Palette: r.pal,
+	}
 	for y := 0; y < rowsTotal; y++ {
 		copy(img.Pix[y*img.Stride:y*img.Stride+colsTotal],
-			cv.pix[(rowsTotal-1-y)*colsTotal:(rowsTotal-y)*colsTotal])
+			r.cv.pix[(rowsTotal-1-y)*colsTotal:(rowsTotal-y)*colsTotal])
 	}
 	return img, nil
+}
+
+// Render computes the SoX-compatible spectrogram image for mono `samples` at
+// `sampleRate`. By default it produces the full SoX PNG layout: raster plus
+// axes, tick labels, dBFS legend, footer comment, and optional title,
+// equivalent to `sox <in> -n spectrogram`. With opt.Raw it renders only the
+// raster (`sox ... spectrogram -r`), oriented like SoX: low frequency at the
+// bottom row, time left-to-right.
+//
+// Every call allocates its own buffers, which makes it safe for concurrent use
+// and the right choice for one-off renders. To render many images at the same
+// Options, see NewRenderer.
+func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted, error) {
+	// Checked before the Options are validated, so that the error a caller sees
+	// for a bad sample rate does not depend on whether the Options are also
+	// wrong. NewRenderer validates in the other order.
+	if !(sampleRate > 0) { // also rejects NaN
+		return nil, fmt.Errorf("sox: sampleRate must be positive, got %g", sampleRate)
+	}
+	r, err := NewRenderer(opt)
+	if err != nil {
+		return nil, err
+	}
+	return r.Render(samples, sampleRate)
 }
 
 // WritePNG renders and encodes to path with the stdlib PNG encoder.
@@ -111,12 +199,28 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 // place would have succeeded. That trade is deliberate: a reader that had the
 // old file open keeps reading a complete image rather than watching one be
 // overwritten underneath it.
-func WritePNG(path string, samples []float32, sampleRate float64, opt Options) (err error) {
+func WritePNG(path string, samples []float32, sampleRate float64, opt Options) error {
 	img, err := Render(samples, sampleRate, opt)
 	if err != nil {
 		return err
 	}
+	return encodePNG(path, img)
+}
 
+// WritePNG renders and encodes to path exactly as the package-level WritePNG
+// does, reusing this Renderer's buffers. The image never escapes, so the reuse
+// is invisible to the caller and this is the safest way to use a Renderer.
+func (r *Renderer) WritePNG(path string, samples []float32, sampleRate float64) error {
+	img, err := r.Render(samples, sampleRate)
+	if err != nil {
+		return err
+	}
+	return encodePNG(path, img)
+}
+
+// encodePNG is the write half of WritePNG; see its doc comment for why the
+// write goes via a temporary file.
+func encodePNG(path string, img *image.Paletted) (err error) {
 	// Same directory as the destination, so the rename cannot cross a
 	// filesystem boundary. A unique name keeps concurrent writers of the same
 	// destination from sharing a temporary.

--- a/sox/sox.go
+++ b/sox/sox.go
@@ -1,159 +1,12 @@
 package sox
 
 import (
-	"fmt"
 	"image"
-	"image/color"
 	"image/png"
 	"os"
 	"path/filepath"
 	"sync"
 )
-
-// Renderer renders repeatedly at one fixed Options, holding on to every buffer
-// a render needs instead of rebuilding them per call. A consumer producing many
-// images at a single preset, which is the usual way this package is used, pays
-// the allocations once rather than about 2.7 MB across ~580 allocations per
-// image, along with the transform plan's ~1000 sincos calls.
-//
-// It is strictly an optimisation: for any given clip it produces exactly the
-// image the free Render produces, and Render is implemented on top of it.
-//
-// Two things are traded for that. The returned image's Pix array is reused, so
-// it is overwritten by the next call on the same Renderer; a caller that needs
-// to keep an image must copy it or use WritePNG, which encodes before returning.
-// And a Renderer is stateful, so it must not be used from more than one
-// goroutine at a time. Render itself stays safe for concurrent use, since it
-// builds its own. Callers wanting both reuse and concurrency should keep a
-// sync.Pool of Renderers, one in flight per goroutine.
-//
-// The buffers are grow-only, sized by the longest clip rendered so far. Drop
-// the Renderer to release them.
-type Renderer struct {
-	o    Options // normalized and validated
-	dft  int
-	rows int
-
-	// Fixed by Options, so computed once: the palette every returned image
-	// shares, the number of goroutines to fan out over, and the raw sum of the
-	// full-length window, which is what sizes the hop.
-	pal            color.Palette
-	workers        int
-	spectrumPoints int
-	windowSum      float64
-
-	scratch analysisScratch
-	cv      canvas
-	pix     []uint8
-}
-
-// NewRenderer validates opt once and prepares the buffers for it. It returns
-// the same errors Render would for the same Options, just at construction
-// rather than on the first clip.
-func NewRenderer(opt Options) (*Renderer, error) {
-	o := normalize(opt)
-	if err := validate(o); err != nil {
-		return nil, err
-	}
-	dft, rows := deriveDFTSize(o)
-	return &Renderer{
-		o: o, dft: dft, rows: rows,
-		pal:            makePalette(o),
-		workers:        resolveWorkers(o.Workers),
-		spectrumPoints: spectrumPoints(o),
-		// The full-length window is only needed for its sum; each analysis
-		// goroutine reshapes its own copy from there.
-		windowSum: makeWindow(newWindowState(dft, o.Window), 0),
-	}, nil
-}
-
-// Render computes the spectrogram image for mono `samples` at `sampleRate`,
-// reusing the buffers from the previous call.
-//
-// The returned image aliases those buffers: its Pix contents are overwritten by
-// the next Render on this Renderer. The header itself is fresh each call, so an
-// image held from an earlier call keeps its own Rect and Stride. Its Palette is
-// shared by every image this Renderer returns and must not be modified, which
-// is a fair reading of an image's palette in any case.
-func (r *Renderer) Render(samples []float32, sampleRate float64) (*image.Paletted, error) {
-	if !(sampleRate > 0) { // also rejects NaN
-		return nil, fmt.Errorf("sox: sampleRate must be positive, got %g", sampleRate)
-	}
-	o := r.o
-	duration := float64(len(samples)) / sampleRate
-	xSize, pps := resolveTimeAxis(o, duration)
-	step, blocks, norm := stepSizing(r.windowSum, r.dft, sampleRate, pps, o.SlackOverlap)
-
-	a, err := analyze(analyzerOpts{
-		dftSize: r.dft, rows: r.rows,
-		stepSize: step, blockSteps: blocks, blockNorm: norm,
-		gain: -o.Gain, dBRange: o.DBRange,
-		spectrumPoints: r.spectrumPoints,
-		xSize:          xSize,
-		normalize:      o.Normalize,
-		window:         o.Window,
-		workers:        r.workers,
-	}, samples, &r.scratch)
-	if err != nil {
-		return nil, fmt.Errorf("sox: analyzing at DFT size %d: %w", r.dft, err)
-	}
-	cols := a.cols
-
-	autogain := 0.0
-	if o.Normalize {
-		autogain = -a.max
-		a.quantise(autogain)
-	}
-
-	colsTotal, rowsTotal := cols, r.rows
-	rasterX, rasterY := 0, 0
-	if !o.Raw {
-		colsTotal, rowsTotal = chromeDims(cols, r.rows, o.Title)
-		rasterX, rasterY = left, below
-	}
-
-	// Draw in SoX's bottom-up coordinates, then blit flipped.
-	n := colsTotal * rowsTotal
-	r.cv.pix, r.cv.cols = growU8(r.cv.pix, n), colsTotal
-	if !o.Raw {
-		// Chrome paints only its text, ticks and border, and takes the rest of
-		// the canvas already being the background colour (palette index 0). On a
-		// reused buffer that has to be made true again, or the previous image's
-		// chrome ghosts through. With Raw the blit below covers every byte, so
-		// the clear is skipped rather than merely being unnecessary.
-		clear(r.cv.pix)
-	}
-	rasterBlit{
-		dst: r.cv.pix, src: a.idx,
-		cols: cols, rows: r.rows,
-		rasterX: rasterX, rasterY: rasterY, colsTotal: colsTotal,
-	}.run(r.workers)
-	if !o.Raw {
-		drawChrome(&r.cv, chromeParams{
-			rasterCols: cols,
-			rasterRows: r.rows,
-			colsTotal:  colsTotal,
-			rowsTotal:  rowsTotal,
-			secs:       float64(cols) * float64(step) * float64(blocks) / sampleRate,
-			sampleRate: sampleRate,
-			autogain:   autogain,
-			o:          o,
-		})
-	}
-
-	r.pix = growU8(r.pix, n)
-	img := &image.Paletted{
-		Pix:     r.pix,
-		Stride:  colsTotal,
-		Rect:    image.Rect(0, 0, colsTotal, rowsTotal),
-		Palette: r.pal,
-	}
-	for y := 0; y < rowsTotal; y++ {
-		copy(img.Pix[y*img.Stride:y*img.Stride+colsTotal],
-			r.cv.pix[(rowsTotal-1-y)*colsTotal:(rowsTotal-y)*colsTotal])
-	}
-	return img, nil
-}
 
 // Render computes the SoX-compatible spectrogram image for mono `samples` at
 // `sampleRate`. By default it produces the full SoX PNG layout: raster plus
@@ -168,9 +21,11 @@ func (r *Renderer) Render(samples []float32, sampleRate float64) (*image.Palette
 func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted, error) {
 	// Checked before the Options are validated, so that the error a caller sees
 	// for a bad sample rate does not depend on whether the Options are also
-	// wrong. NewRenderer validates in the other order.
-	if !(sampleRate > 0) { // also rejects NaN
-		return nil, fmt.Errorf("sox: sampleRate must be positive, got %g", sampleRate)
+	// wrong. NewRenderer validates in the other order, so this ordering is a
+	// contract of the free function rather than an accident of the delegation;
+	// TestRenderErrorPrecedence pins it.
+	if err := checkSampleRate(sampleRate); err != nil {
+		return nil, err
 	}
 	r, err := NewRenderer(opt)
 	if err != nil {
@@ -201,17 +56,6 @@ func Render(samples []float32, sampleRate float64, opt Options) (*image.Paletted
 // overwritten underneath it.
 func WritePNG(path string, samples []float32, sampleRate float64, opt Options) error {
 	img, err := Render(samples, sampleRate, opt)
-	if err != nil {
-		return err
-	}
-	return encodePNG(path, img)
-}
-
-// WritePNG renders and encodes to path exactly as the package-level WritePNG
-// does, reusing this Renderer's buffers. The image never escapes, so the reuse
-// is invisible to the caller and this is the safest way to use a Renderer.
-func (r *Renderer) WritePNG(path string, samples []float32, sampleRate float64) error {
-	img, err := r.Render(samples, sampleRate)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`Render` rebuilt every buffer it needed on each call: the analysis output, the canvas, the image, the schedule, the per-worker DSP state and the FFT plan. At 1026x513 that is 2.13 MiB across 447 allocations, plus a transform plan rebuild, paid again for every image. The usual way this package is consumed is many clips at one fixed preset, where all of it is rebuilt identically each time.

This adds an opt-in `Renderer` that owns those buffers for a fixed `Options`. `Render` and `WritePNG` keep their exact signatures and become thin wrappers over it, so there is one pipeline rather than two and a one-off render allocates what it always did.

```go
r, err := sox.NewRenderer(sox.Options{XSize: 1026, YSize: 513})
for _, clip := range clips {
    if err := r.WritePNG(clip.out, clip.samples, clip.rate); err != nil { ... }
}
```

## Measured

Quiet hosts, `GOMAXPROCS=4`, amd64 pinned to four P-cores, medians of ten runs via benchstat. Same 15 s 24 kHz clip as the existing benchmarks.

| size | amd64 `Render` | reused | arm64 `Render` | reused |
|---|---|---|---|---|
| 258 x 129 | 780.2 us | **681.4 us** | 2.223 ms | **1.856 ms** |
| 514 x 257 | 919.1 us | **761.7 us** | 2.801 ms | **2.287 ms** |
| 1026 x 513 | 1.697 ms | **1.517 ms** | 5.620 ms | **4.539 ms** |
| 2050 x 1025 | 5.744 ms | **5.251 ms** | 19.70 ms | **17.75 ms** |

9-19% off `Render` and 1-10% off `WritePNG`, where the unchanged PNG encode dominates. Allocation is the larger effect: at 1026 x 513, 2.13 MiB across 447 allocations becomes 1785 B across 97, and 1088 B across 11 in `Raw` mode. Over 2000 renders at that size the collector ran 3956 times against 434.

What remains is chrome formatting its tick labels through `fmt` and one closure per worker per pass, neither of which this touches.

## Correctness

The failure mode here is a silently wrong image rather than a crash, so the reset path is explicit and commented at each site: the frame-priming flag, the `-n` autogain reference, the appended schedule slices, and the canvas, which chrome only partly paints. `analyze` also now rejects a scratch reused under a different window, the one piece of baked-in state the existing bin-count check did not cover.

Verified bit-exact against the SoX 14.4.2 binary on amd64 and arm64, and again with `SIMD_DISABLE=all`. Race detector clean on amd64 (it cannot run on a Pi 5, whose kernel has a 47-bit VMA).

New tests render a sequence of deliberately awkward clips through one reused Renderer and compare every one against a fresh `Render`, over the full `Options` matrix: loud then quiet, long then short, a differing sample rate, non-finite samples, one shorter than a DFT frame, and an empty clip. Each case's intended branch was verified to be reached rather than assumed, including the one whose dBFS buffer has to grow on a live Renderer and the one that pins partial fan-out with an explicit worker count so it does not depend on the runner's core count.

## Notes for review

- The returned image aliases the reused pixel buffer and must be treated as invalid after the next `Render`; the header is fresh each call, and `WritePNG` encodes before returning so the batch path never sees it. A `Renderer` is single-goroutine; `Render` itself stays safe for concurrent use and now has a test saying so.
- Buffers are grow-only with geometric growth, so a caller driving the time axis with `PixelsPerSec` does not reallocate on every slightly longer clip.
- The worker count is resolved per render, not cached, so a long-lived Renderer tracks a `GOMAXPROCS` that Go adjusts at runtime from the cgroup CPU limit.
- `Renderer` lives in its own file, matching the pairing every other type in the package has.